### PR TITLE
Port five security findings from AP Platform and MSAM Web

### DIFF
--- a/source/dotnet/APIs/Approvals.CoreServices/Controllers/BaseApiController.cs
+++ b/source/dotnet/APIs/Approvals.CoreServices/Controllers/BaseApiController.cs
@@ -6,6 +6,7 @@ namespace Microsoft.CFS.Approvals.CoreServices.Controllers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.CFS.Approvals.Contracts;
 using Microsoft.CFS.Approvals.Contracts.DataContracts;
@@ -19,6 +20,7 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 [Route("api/v1/[controller]")]
 [ApiController]
+[Authorize]
 public class BaseApiController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/APIs/Approvals.CoreServices/Controllers/api/v1/DocumentDownloadController.cs
+++ b/source/dotnet/APIs/Approvals.CoreServices/Controllers/api/v1/DocumentDownloadController.cs
@@ -101,6 +101,10 @@ public class DocumentDownloadController : BaseApiController
 
             return File(httpResponseMessage, "application/octet-stream");
         }
+        catch (UnauthorizedAccessException ex)
+        {
+            return StatusCode(403, ex.Message);
+        }
         catch (Exception ex)
         {
             return BadRequest(ex.Message);
@@ -137,13 +141,18 @@ public class DocumentDownloadController : BaseApiController
                    tcv,
                    requestBody,
                    OnBehalfUser.MailNickname,
-                   SignedInUser.MailNickname,
+                   SignedInUser,
                    ClientDevice,
                    GetTokenOrCookie(),
                    OnBehalfUser.Id,
                    DomainName);
 
             return File(httpResponseMessage, "application/octet-stream");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            // Caller is not the approver and holds no delegation grant for the requested alias.
+            return StatusCode(403, ex.Message);
         }
         catch (Exception ex)
         {

--- a/source/dotnet/APIs/Approvals.CoreServices/Controllers/api/v1/DocumentPreviewController.cs
+++ b/source/dotnet/APIs/Approvals.CoreServices/Controllers/api/v1/DocumentPreviewController.cs
@@ -112,7 +112,7 @@ public class DocumentPreviewController : BaseApiController
         }
         catch (Exception ex)
         {
-            return BadRequest(ex.Message);
+            return BadRequest(Constants.DocumentPreviewErrorMessage);
         }
     }
 

--- a/source/dotnet/APIs/Approvals.CoreServices/Controllers/api/v1/PullTenantController.cs
+++ b/source/dotnet/APIs/Approvals.CoreServices/Controllers/api/v1/PullTenantController.cs
@@ -55,10 +55,9 @@ public class PullTenantController : BaseApiController
             ArgumentGuard.NotNull(tenantId, nameof(tenantId));
 
             var parameters = GetFilterParameters();
-            if (!parameters.ContainsKey("alias"))
-            {
-                parameters.Add("alias", OnBehalfUser.MailNickname);
-            }
+            // SECURITY FIX: Unconditionally overwrite the alias parameter with the server-derived value
+            // to prevent authorization bypass through user-controlled parameters
+            parameters["alias"] = OnBehalfUser.MailNickname;
 
             var summaryData = await _pullTenantHelper.GetSummaryAsync(SignedInUser, OnBehalfUser, GetTokenOrCookie(), parameters, tenantId, ClientDevice, sessionId, Xcv, MessageId);
             return Ok(summaryData);
@@ -93,10 +92,9 @@ public class PullTenantController : BaseApiController
         try
         {
             var parameters = GetFilterParameters();
-            if (!parameters.ContainsKey("alias"))
-            {
-                parameters.Add("alias", OnBehalfUser.MailNickname);
-            }
+            // SECURITY FIX: Unconditionally overwrite the alias parameter with the server-derived value
+            // to prevent authorization bypass through user-controlled parameters
+            parameters["alias"] = OnBehalfUser.MailNickname;
 
             if (!parameters.ContainsKey(Constants.DocumentNumber))
             {

--- a/source/dotnet/APIs/Approvals.CoreServices/Program.cs
+++ b/source/dotnet/APIs/Approvals.CoreServices/Program.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using Azure.AI.OpenAI;
 using Azure.Identity;
 using Azure.Storage.Blobs;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Azure.Cosmos;
 using Microsoft.CFS.Approvals.Common.BL;
@@ -87,6 +88,14 @@ builder.Services.AddControllers().AddNewtonsoftJson(options =>
 });
 
 builder.Services.AddRouting(options => options.LowercaseUrls = true);
+
+builder.Services
+    .AddAuthentication("EasyAuth")
+    .AddScheme<AuthenticationSchemeOptions, EasyAuthAuthenticationHandler>("EasyAuth", options =>
+    {
+    });
+
+builder.Services.AddAuthorization();
 
 // Register the Swagger generator, defining one or more Swagger documents
 builder.Services.AddSwaggerGen(c =>
@@ -253,6 +262,10 @@ app.UseSwagger(c =>
 app.UseHttpsRedirection();
 
 app.UseRouting();
+
+app.UseAuthentication();
+
+app.UseAuthorization();
 
 app.UseMiddleware<AuthorizationMiddleware>();
 

--- a/source/dotnet/APIs/Approvals.CoreServices/Utils/AuthorizationMiddleware.cs
+++ b/source/dotnet/APIs/Approvals.CoreServices/Utils/AuthorizationMiddleware.cs
@@ -12,11 +12,8 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.CFS.Approvals.Contracts;
-using Microsoft.CFS.Approvals.Contracts.DataContracts;
 using Microsoft.CFS.Approvals.Core.BL.Interface;
 using Microsoft.CFS.Approvals.Extensions;
-using Microsoft.CFS.Approvals.Model;
-using Microsoft.CFS.Approvals.Utilities.Interface;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -27,22 +24,15 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 public class AuthorizationMiddleware : IMiddleware
 {
-    private readonly IDelegationHelper _delegationHelper;
     private readonly IApprovalTenantInfoHelper _approvalTenantInfoHelper;
-    private readonly INameResolutionHelper _nameResolutionHelper;
     private readonly IConfiguration _configuration;
-    private static readonly string XMsClientPrincipalIdp = "X-MS-CLIENT-PRINCIPAL-IDP";
-    private static readonly string XMsClientPrincipalId = "X-MS-CLIENT-PRINCIPAL-ID";
-    private static readonly string XMsClientPrincipal = "X-MS-CLIENT-PRINCIPAL";
 
     /// <summary>
     /// Constructor
     /// </summary>
-    public AuthorizationMiddleware(IApprovalTenantInfoHelper approvalTenantInfoHelper, IDelegationHelper delegationHelper, INameResolutionHelper nameResolutionHelper, IConfiguration configuration)
+    public AuthorizationMiddleware(IApprovalTenantInfoHelper approvalTenantInfoHelper, IConfiguration configuration)
     {
-        _delegationHelper = delegationHelper;
         _approvalTenantInfoHelper = approvalTenantInfoHelper;
-        _nameResolutionHelper = nameResolutionHelper;
         _configuration = configuration;
     }
 
@@ -54,16 +44,53 @@ public class AuthorizationMiddleware : IMiddleware
     /// <returns></returns>
     public async Task InvokeAsync(HttpContext context, RequestDelegate next)
     {
-        var claims = new List<Claim>();
-        var userAlias = string.Empty;
-        var userPrincipalName = string.Empty;
-        string currentDomain = string.Empty;
-        List<UserDelegationSetting> currentUserDelegation = null;
-
-        // Get UserPrincipalName /alias from Header
-        if (context.Request.Headers.Keys.Contains("X-MS-CLIENT-PRINCIPAL-NAME"))
+        // Always strip reserved headers injected by clients.
+        if (context.Request.Headers.ContainsKey(Constants.LoggedInUserAlias))
         {
-            userPrincipalName = context.Request.Headers["X-MS-CLIENT-PRINCIPAL-NAME"].ToString();
+            context.Request.Headers.Remove(Constants.LoggedInUserAlias);
+        }
+
+        // SECURITY: Reject requests that bypass EasyAuth (App Service Authentication)
+        if (!EasyAuthPrincipalHelper.TryBuildPrincipal(context.Request.Headers, nameof(AuthorizationMiddleware), out var principal, out _))
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsync("Unauthorized request");
+            return;
+        }
+
+        context.User = principal;
+
+        if (context.User != null)
+        {
+
+            #region Check for Valid AppID
+
+            // Get list of AppIds
+            var validAppIds = Environment.GetEnvironmentVariable("ValidAppIds");
+            var listOfValidAppIds = validAppIds.Split(';');
+
+
+            // Check azp (user-delegated tokens) first, then appid (app-only tokens)
+            // SECURITY: Do NOT fallback to aud claim as it represents the API's own client ID
+            var clientAppId = GetClaimValue(context.User, "azp", "appid");
+
+            // if clientAppId is null or not in the Valid AppId list then return UnAuthorized Response
+            if (string.IsNullOrWhiteSpace(clientAppId) || !listOfValidAppIds.Any(id => id.Equals(clientAppId, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                await context.Response.WriteAsync("Unauthorized request - invalid client application");
+                return;
+            }
+            else
+            {
+                context.Request.Headers.Add(Constants.AppClientId, clientAppId);
+            }
+
+            #endregion Check for Valid AppID
+
+            var userAlias = string.Empty;
+            var currentDomain = string.Empty;
+            var userPrincipalName = GetClaimValue(context.User, ClaimTypes.Upn, "upn", "preferred_username");
             var whitelistedDomains = _configuration[Constants.WhitelistedDomains]?.Split(";").ToList();
             whitelistedDomains.ForEach(domain =>
             {
@@ -74,79 +101,14 @@ public class AuthorizationMiddleware : IMiddleware
                 }
             });
 
-            context.Request.Headers.Add(Constants.LoggedInUserUpn, userPrincipalName);
-        }
-
-        // Authorize after the user has been authenticated by App Service Authentication Service
-        if (context.Request.Headers.ContainsKey(XMsClientPrincipalIdp))
-        {
-            if (context.Request.Headers.ContainsKey(XMsClientPrincipal))
-            {
-                var clientPrincipal = JsonConvert.DeserializeObject<JObject>(
-                    Encoding.UTF8.GetString(Convert.FromBase64String(context.Request.Headers[XMsClientPrincipal].FirstOrDefault())));
-                foreach (var claimObj in clientPrincipal["claims"]?.ToObject<JObject[]>())
-                {
-                    claims.Add(new Claim(claimObj["typ"]?.ToString(), claimObj["val"]?.ToString()));
-                }
-            }
-            context.User = new ClaimsPrincipal(new ClaimsIdentity(claims));
-
-            #region Check for Valid AppID
-
-            // Get list of AppIds
-            var validAppIds = Environment.GetEnvironmentVariable("ValidAppIds");
-            var listOfValidAppIds = validAppIds.Split(';');
-
-            if (context.User != null)
-            {
-                var appid = context.User.Claims.FirstOrDefault(c => c.Type.Equals("appid")) ?? context.User.Claims.FirstOrDefault(c => c.Type.Equals("aud"));
-
-                // if AppId is null or the AppId fetched from claims is different from the Valid AppId list value then return UnAuthorized Response
-                if (appid == null || !listOfValidAppIds.Any(id => id.Equals(appid.Value, StringComparison.InvariantCultureIgnoreCase)))
-                {
-                    context.Response.StatusCode = StatusCodes.Status401Unauthorized;
-                    await context.Response.WriteAsync("Unauthorized request");
-                    return;
-                }
-            }
-
-            #endregion Check for Valid AppID
-
-            #region Check for Reserved Headers
-
-            if (context.Request.Headers.ContainsKey(Constants.LoggedInUserAlias))
-            {
-                // Logging the details of LoggedInUserAliasHeader header and actual logged in alias details
-                var loggedInUserAliasHeaderValue = context.Request.Headers.FirstOrDefault(x => x.Key.ToLower().Equals(Constants.LoggedInUserAlias.ToLower())).Value.FirstOrDefault();
-
-                // Throwing back a bad request so that this message is not processed
-                context.Response.StatusCode = StatusCodes.Status403Forbidden;
-                await context.Response.WriteAsync("Forbidden: You are not allowed to send a reserved httpHeader value under LoggedInUserAliasHeader. This is an invalid request and will not be processed.");
-                return;
-            }
-            else
-            {
-                context.Request.Headers.Add(Constants.LoggedInUserAlias, userAlias);
-                if (context.Request.Headers.ContainsKey(Constants.LoggedInUserUpn))
-                    context.Request.Headers[Constants.LoggedInUserUpn] = userPrincipalName;
-                else
-                    context.Request.Headers.Add(Constants.LoggedInUserUpn, userPrincipalName);
-            }
-
-            #endregion Check for Reserved Headers
+            context.Request.Headers[Constants.LoggedInUserAlias] = userAlias;
+            context.Request.Headers[Constants.LoggedInUserUpn] = userPrincipalName;
 
             #region Check for Delegation Headers
 
             if (!string.IsNullOrWhiteSpace(currentDomain))
             {
-                if (context.Request.Headers.ContainsKey(Constants.Domain))
-                {
-                    context.Request.Headers[Constants.Domain] = currentDomain;
-                }
-                else
-                {
-                    context.Request.Headers.Add(Constants.Domain, currentDomain);
-                }
+                context.Request.Headers[Constants.Domain] = currentDomain;
             }
             if (!string.IsNullOrWhiteSpace(userAlias))
             {
@@ -180,7 +142,7 @@ public class AuthorizationMiddleware : IMiddleware
                 }
                 else if (!context.Request.Headers.ContainsKey(Constants.UserAlias))
                 {
-                    context.Request.Headers.Add(Constants.UserAlias, userAlias);
+                    context.Request.Headers[Constants.UserAlias] = userAlias;
                 }
                 else
                 {
@@ -190,7 +152,26 @@ public class AuthorizationMiddleware : IMiddleware
 
             #endregion Check for Delegation Headers
         }
-
         await next(context);
+    }
+
+    /// <summary>
+    /// Gets the claim value from the claims principal based on the provided claim types.
+    /// </summary>
+    /// <param name="principal">The claims principal.</param>
+    /// <param name="claimTypes">The claim types to search for.</param>
+    /// <returns>The claim value if found; otherwise, an empty string.</returns>
+    private static string GetClaimValue(ClaimsPrincipal principal, params string[] claimTypes)
+    {
+        foreach (var claimType in claimTypes)
+        {
+            var value = principal.Claims.FirstOrDefault(c => c.Type.Equals(claimType, StringComparison.InvariantCultureIgnoreCase))?.Value;
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return string.Empty;
     }
 }

--- a/source/dotnet/APIs/Approvals.CoreServices/Utils/EasyAuthAuthenticationHandler.cs
+++ b/source/dotnet/APIs/Approvals.CoreServices/Utils/EasyAuthAuthenticationHandler.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.CFS.Approvals.CoreServices.Utils;
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+public class EasyAuthAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public EasyAuthAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        System.Text.Encodings.Web.UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!EasyAuthPrincipalHelper.TryBuildPrincipal(Request.Headers, Scheme.Name, out var principal, out var error))
+        {
+            return Task.FromResult(AuthenticateResult.Fail(error));
+        }
+
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/source/dotnet/APIs/Approvals.CoreServices/Utils/EasyAuthPrincipalHelper.cs
+++ b/source/dotnet/APIs/Approvals.CoreServices/Utils/EasyAuthPrincipalHelper.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.CFS.Approvals.CoreServices.Utils;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+
+internal static class EasyAuthPrincipalHelper
+{
+    internal const string XMsClientPrincipalIdp = "X-MS-CLIENT-PRINCIPAL-IDP";
+    internal const string XMsClientPrincipal = "X-MS-CLIENT-PRINCIPAL";
+
+    internal static bool TryBuildPrincipal(IHeaderDictionary headers, string authenticationType, out ClaimsPrincipal principal, out string error)
+    {
+        principal = null;
+        error = null;
+
+        if (!headers.ContainsKey(XMsClientPrincipalIdp) || !headers.ContainsKey(XMsClientPrincipal))
+        {
+            error = "EasyAuth headers are missing.";
+            return false;
+        }
+
+        var encodedPrincipal = headers[XMsClientPrincipal].FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(encodedPrincipal))
+        {
+            error = "EasyAuth principal header is empty.";
+            return false;
+        }
+
+        try
+        {
+            var claims = new List<Claim>();
+            var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(encodedPrincipal));
+
+            using var document = JsonDocument.Parse(decoded);
+            if (document.RootElement.TryGetProperty("claims", out var claimsElement) && claimsElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var claimObject in claimsElement.EnumerateArray())
+                {
+                    if (!claimObject.TryGetProperty("typ", out var typeElement) || !claimObject.TryGetProperty("val", out var valueElement))
+                    {
+                        continue;
+                    }
+
+                    var claimType = typeElement.GetString();
+                    var claimValue = valueElement.GetString();
+                    if (!string.IsNullOrWhiteSpace(claimType) && !string.IsNullOrWhiteSpace(claimValue))
+                    {
+                        claims.Add(new Claim(claimType, claimValue));
+                    }
+                }
+            }
+
+            if (!claims.Any())
+            {
+                error = "No claims found in EasyAuth principal.";
+                return false;
+            }
+
+            principal = new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType));
+            return true;
+        }
+        catch
+        {
+            error = "Invalid EasyAuth principal format.";
+            return false;
+        }
+    }
+}

--- a/source/dotnet/APIs/Approvals.PayloadReceiverService/Controllers/api/v1/PayloadReceiverController.cs
+++ b/source/dotnet/APIs/Approvals.PayloadReceiverService/Controllers/api/v1/PayloadReceiverController.cs
@@ -5,8 +5,10 @@ namespace Microsoft.CFS.Approvals.PayloadReceiverService.Controllers.api.v1;
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.CFS.Approvals.Contracts.DataContracts;
@@ -18,6 +20,7 @@ using Swashbuckle.AspNetCore.Annotations;
 /// </summary>
 [Route("api/v1/[controller]")]
 [ApiController]
+[Authorize]
 public class PayloadReceiverController : ControllerBase
 {
     /// <summary>
@@ -58,11 +61,22 @@ public class PayloadReceiverController : ControllerBase
         try
         {
             string payload = string.Empty;
+            string callerAppId = User?.Claims?.FirstOrDefault(c => c.Type.Equals("azp", StringComparison.InvariantCultureIgnoreCase) || c.Type.Equals("appid", StringComparison.InvariantCultureIgnoreCase))?.Value;
+
             using (StreamReader reader = new StreamReader(Request.Body, Encoding.UTF8))
             {
                 payload = await reader.ReadToEndAsync();
             }
-            return Ok(await _payloadReceiverManager.ManagePost(tenantId, payload));
+
+            return Ok(await _payloadReceiverManager.ManagePost(tenantId, payload, callerAppId));
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return StatusCode(StatusCodes.Status401Unauthorized, ex.Message);
+        }
+        catch (InvalidDataException ex)
+        {
+            return BadRequest(ex.Message);
         }
         catch (Exception ex)
         {

--- a/source/dotnet/APIs/Approvals.PayloadReceiverService/Program.cs
+++ b/source/dotnet/APIs/Approvals.PayloadReceiverService/Program.cs
@@ -168,6 +168,8 @@ app.UseRouting();
 
 app.UseMiddleware<AuthorizationMiddleware>();
 
+app.UseAuthorization();
+
 app.UseEndpoints(endpoints =>
 {
     endpoints.MapControllers();

--- a/source/dotnet/APIs/Approvals.PayloadReceiverService/Utils/AuthorizationMiddleware.cs
+++ b/source/dotnet/APIs/Approvals.PayloadReceiverService/Utils/AuthorizationMiddleware.cs
@@ -31,6 +31,13 @@ public class AuthorizationMiddleware : IMiddleware
     {
         var claims = new List<Claim>();
 
+        if (!context.Request.Headers.ContainsKey(XMsClientPrincipalIdp) || !context.Request.Headers.ContainsKey(XMsClientPrincipal))
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsync("Unauthorized request");
+            return;
+        }
+
         // Authorize after the user has been authenticated by App Service Authentication Service
         if (context.Request.Headers.ContainsKey(XMsClientPrincipalIdp))
         {
@@ -47,16 +54,20 @@ public class AuthorizationMiddleware : IMiddleware
 
             #region Check for Valid AppID
 
-            // Get list of AppIds
-            var validAppIds = Environment.GetEnvironmentVariable("ValidAppIds");
-            var listOfValidAppIds = validAppIds.Split(';');
-
             if (context.User != null)
             {
-                var appid = context.User.Claims.FirstOrDefault(c => c.Type.Equals("appid")) ?? context.User.Claims.FirstOrDefault(c => c.Type.Equals("aud"));
+                var clientAppId = GetClaimValue(context.User, "azp", "appid");
+                if (string.IsNullOrWhiteSpace(clientAppId))
+                {
+                    context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                    await context.Response.WriteAsync("Unauthorized request");
+                    return;
+                }
 
-                // if AppId is null or the AppId fetched from claims is different from the Valid AppId list value then return UnAuthorized Response
-                if (appid == null || !listOfValidAppIds.Any(id => id.Equals(appid.Value, StringComparison.InvariantCultureIgnoreCase)))
+                var validAppIds = Environment.GetEnvironmentVariable("ValidAppIds");
+                var listOfValidAppIds = validAppIds?.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? Array.Empty<string>();
+
+                if (!listOfValidAppIds.Any(id => id.Equals(clientAppId, StringComparison.InvariantCultureIgnoreCase)))
                 {
                     context.Response.StatusCode = StatusCodes.Status401Unauthorized;
                     await context.Response.WriteAsync("Unauthorized request");
@@ -68,5 +79,25 @@ public class AuthorizationMiddleware : IMiddleware
         }
 
         await next(context);
+    }
+
+    /// <summary>
+    /// Gets the claim value from the claims principal based on the provided claim types.
+    /// </summary>
+    /// <param name="principal">The claims principal.</param>
+    /// <param name="claimTypes">The claim types to search for.</param>
+    /// <returns>The claim value if found; otherwise, an empty string.</returns>
+    private static string GetClaimValue(ClaimsPrincipal principal, params string[] claimTypes)
+    {
+        foreach (var claimType in claimTypes)
+        {
+            var value = principal.Claims.FirstOrDefault(c => c.Type.Equals(claimType, StringComparison.InvariantCultureIgnoreCase))?.Value;
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return string.Empty;
     }
 }

--- a/source/dotnet/Contract/Approvals.Contracts/Constants.cs
+++ b/source/dotnet/Contract/Approvals.Contracts/Constants.cs
@@ -311,6 +311,8 @@ namespace Microsoft.CFS.Approvals.Contracts
         public const string OnBehalfUserUpn = "OnBehalfUserUpn";
         public const string OnBehalfUserId = "OnBehalfUserId";
         public const string LoggedInUserAlias = "LoggedInUserAlias";
+        public const string AppClientId = "AppClientId";
+        public const string EasyAuthScheme = "EasyAuth";
         public const string Tenants = "Tenants";
         public const string LoggedInUserUpn = "LoggedInUserUpn";
         public const string DelegatedUserAlias = "DelegatedUserAlias";

--- a/source/dotnet/Contract/Approvals.Contracts/Constants.cs
+++ b/source/dotnet/Contract/Approvals.Contracts/Constants.cs
@@ -396,6 +396,7 @@ namespace Microsoft.CFS.Approvals.Contracts
         public const string QuickTourAPIErrorMessage = "Failed to fetch Quick tour features";
 
         public const string DownloadAllAttachmentsFile = "AllAttachments.zip";
+        public const string DocumentPreviewErrorMessage = "Not able to preview the document at this time. Please try again later or contact support.";
 
         public const string AdaptiveTemplateVersion = "1.0";
 

--- a/source/dotnet/Contract/Approvals.Model/ApprovalTenantInfo.cs
+++ b/source/dotnet/Contract/Approvals.Model/ApprovalTenantInfo.cs
@@ -58,6 +58,11 @@ public class ApprovalTenantInfo : BaseTableEntity
     public string RegisteredClients { get; set; }
 
     /// <summary>
+    /// Gets or sets the registered client identifier.
+    /// </summary>
+    public string RegisteredClientId { get; set; }
+
+    /// <summary>
     /// Gets or sets the Actionable NotificationTemplate Keys
     /// </summary>
     public string ActionableNotificationTemplateKeys { get; set; }

--- a/source/dotnet/Core/Approvals.Core.BL/Helpers/BulkExternalDocumentActionHelper.cs
+++ b/source/dotnet/Core/Approvals.Core.BL/Helpers/BulkExternalDocumentActionHelper.cs
@@ -149,6 +149,8 @@ public class BulkExternalDocumentActionHelper : DocumentActionHelper
 
         try
         {
+            await _delegationHelper.CheckUserAuthorization(signedInUser, onBehalfUser, oauth2UserToken, clientDevice, sessionId, xcv, tcv);
+
             var tenantOperations = tenantInfo.DetailOperations.DetailOpsList;
             var operation = tenantOperations.FirstOrDefault(item => item.operationtype == Constants.OperationTypeOutOfSync);
 
@@ -166,6 +168,12 @@ public class BulkExternalDocumentActionHelper : DocumentActionHelper
                 var approvalRequestsToTenant = JsonConvert.DeserializeObject<List<ApprovalRequest>>(approvalRequests.ToJson());
                 foreach (var approvalRequest in approvalRequestsToTenant)
                 {
+                    if (!string.IsNullOrEmpty(approvalRequest.ActionByAlias) &&
+                        !approvalRequest.ActionByAlias.Equals(onBehalfUser.MailNickname, StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        throw new UnauthorizedAccessException(_config[ConfigurationKey.UnAuthorizedException.ToString()]);
+                    }
+
                     approvalRequest.AdditionalData.Remove("summaryJSON");
                 }
                 actionResponse = await tenantAdapter.ExecuteActionAsync(approvalRequestsToTenant, signedInUser.MailNickname, sessionId, clientDevice, xcv, tcv, null);

--- a/source/dotnet/Core/Approvals.Core.BL/Helpers/DelegationHelper.cs
+++ b/source/dotnet/Core/Approvals.Core.BL/Helpers/DelegationHelper.cs
@@ -269,10 +269,10 @@ public class DelegationHelper : IDelegationHelper
 
                 var tenantAdapter = _tenantFactory.GetTenant(tenant);
 
-                Dictionary<string, object> parameters = new Dictionary<string, object> { { "alias", onBehalfUser.MailNickname } };
+                Dictionary<string, object> parameters = new Dictionary<string, object> { { "alias", signedInUser.MailNickname } };
 
                 // Get the details of an approval request from tenant system.
-                var httpResponseMessage = await tenantAdapter.GetUsersDelegatedToAsync(onBehalfUser, parameters, clientDevice, xcv, tcv, sessionId);
+                var httpResponseMessage = await tenantAdapter.GetUsersDelegatedToAsync(signedInUser, parameters, clientDevice, xcv, tcv, sessionId);
                 logData.Add(LogDataKey.EndDateTime, DateTime.UtcNow);
                 var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
 

--- a/source/dotnet/Core/Approvals.Core.BL/Helpers/DetailsHelper.cs
+++ b/source/dotnet/Core/Approvals.Core.BL/Helpers/DetailsHelper.cs
@@ -966,13 +966,13 @@ public class DetailsHelper : IDetailsHelper
     /// <param name="tcv">GUID transaction correlation vector for telemetry and logging</param>
     /// <param name="requestContent">Request body which is sent to the LoB application as part of the content in the Http call</param>
     /// <param name="userAlias">Alias of the Approver of this request</param>
-    /// <param name="loggedInAlias">Logged in User Alias</param>
+    /// <param name="signedInUser">Authenticated caller; used to re-verify the delegation grant.</param>
     /// <param name="clientDevice">Client Device (Web/WP8..)</param>
     /// <param name="authorizationToken">Authorization Token</param>
     /// <param name="objectId">Alias's ObjectId</param>
     /// <param name="domain">Alias's Domain</param>
     /// <returns>HttpResponseMessage with Stream data of all the attachments</returns>
-    public async Task<byte[]> GetAllAttachmentsInBulk(int tenantId, string sessionId, string tcv, string requestContent, string userAlias, string loggedInAlias, string clientDevice, string authorizationToken, string objectId, string domain)
+    public async Task<byte[]> GetAllAttachmentsInBulk(int tenantId, string sessionId, string tcv, string requestContent, string userAlias, User signedInUser, string clientDevice, string authorizationToken, string objectId, string domain)
     {
         #region Logging Prep
 
@@ -990,7 +990,7 @@ public class DetailsHelper : IDetailsHelper
         {
             { LogDataKey.Tcv, tcv },
             { LogDataKey.SessionId, sessionId },
-            { LogDataKey.UserRoleName, loggedInAlias },
+            { LogDataKey.UserRoleName, signedInUser?.MailNickname },
             { LogDataKey.TenantId, tenantId },
             { LogDataKey.UserAlias, userAlias },
             { LogDataKey.StartDateTime, DateTime.UtcNow },
@@ -1008,6 +1008,13 @@ public class DetailsHelper : IDetailsHelper
             logData.Add(LogDataKey.BusinessProcessName, string.Format(tenantInfo.BusinessProcessName, Constants.BusinessProcessNameGetDocuments, Constants.BusinessProcessNameUserTriggered));
 
             #endregion Getting the Tenant ID
+
+            // SECURITY: Re-validate the delegation grant server-side (userAlias is client-supplied);
+            // throws UnauthorizedAccessException (=> HTTP 403) if the caller isn't the owner/a delegate.
+            await _delegationHelper.CheckUserAuthorization(
+                signedInUser,
+                new User { MailNickname = userAlias, UserPrincipalName = userAlias + domain, Id = objectId },
+                authorizationToken, clientDevice, sessionId, tcv, tcv);
 
             #region Forh the list of Approval Identifiers
 
@@ -1045,7 +1052,7 @@ public class DetailsHelper : IDetailsHelper
 
             using (var docDownloadTracer = _performanceLogger.StartPerformanceLogger("PerfLog", string.IsNullOrWhiteSpace(clientDevice) ? Constants.WebClient : clientDevice, string.Format(Constants.PerfLogAction, tenantInfo.AppName, "Bulk Document Download"), logData))
             {
-                var response = await tenantAdaptor.BulkDownloadDocumentAsync(approvalRequests, loggedInAlias, sessionId, clientDevice);
+                var response = await tenantAdaptor.BulkDownloadDocumentAsync(approvalRequests, signedInUser?.MailNickname, sessionId, clientDevice);
 
                 if (response != null)
                 {
@@ -1059,6 +1066,14 @@ public class DetailsHelper : IDetailsHelper
                 _logProvider.LogInformation(TrackingEvent.WebApiBulkDocumentDownloadSuccess, logData);
                 return response;
             }
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            // Authorization / delegation failure must surface distinctly (HTTP 403) and not be
+            // masked as a generic internal error.
+            logData.Modify(LogDataKey.EndDateTime, DateTime.UtcNow);
+            _logProvider.LogError(TrackingEvent.WebApiBulkDocumentDownloadFail, ex, logData);
+            throw;
         }
         catch (Exception ex)
         {

--- a/source/dotnet/Core/Approvals.Core.BL/Helpers/DocumentActionHelper.cs
+++ b/source/dotnet/Core/Approvals.Core.BL/Helpers/DocumentActionHelper.cs
@@ -102,7 +102,7 @@ public class DocumentActionHelper : IDocumentActionHelper
     /// <summary>
     /// Delegation helper
     /// </summary>
-    private readonly IDelegationHelper _delegationHelper;
+    protected readonly IDelegationHelper _delegationHelper;
 
     #endregion Variables
 

--- a/source/dotnet/Core/Approvals.Core.BL/Interface/IDetailsHelper.cs
+++ b/source/dotnet/Core/Approvals.Core.BL/Interface/IDetailsHelper.cs
@@ -240,7 +240,7 @@ public interface IDetailsHelper
     /// <param name="tcv">GUID transaction correlation vector for telemetry and logging</param>
     /// <param name="requestContent">Request body which is sent to the LoB application as part of the content in the Http call</param>
     /// <param name="userAlias">Alias of the Approver of this request</param>
-    /// <param name="loggedInAlias">Logged in User Alias</param>
+    /// <param name="signedInUser">Authenticated caller; used to re-verify the delegation grant.</param>
     /// <param name="clientDevice">Client Device (Web/WP8..)</param>
     /// <param name="authorizationToken">Authorization Token</param>
     /// <param name="objectId">Alias's ObjectId</param>
@@ -252,7 +252,7 @@ public interface IDetailsHelper
             string tcv,
             string requestContent,
             string userAlias,
-            string loggedInAlias,
+            User signedInUser,
             string clientDevice,
             string authorizationToken,
             string objectId,

--- a/source/dotnet/Core/Approvals.CoreServices.BL/Helpers/OfficeDocumentCreator.cs
+++ b/source/dotnet/Core/Approvals.CoreServices.BL/Helpers/OfficeDocumentCreator.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.CFS.Approvals.CoreServices.BL.Helpers;
 
+using System;
 using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.CFS.Approvals.CoreServices.BL.Interface;
@@ -37,20 +38,58 @@ public class OfficeDocumentCreator : IOfficeDocumentCreator
     /// <returns></returns>
     public string GetDocumentURL(byte[] officeDocumentContent, string displayDocumentNumber, string attachmentName, string loggedInAlias, string sessionId)
     {
-        string filePath = _hostingEnvironment.WebRootPath + @"\PreviewDocuments";
+        string filePath = Path.Combine(_hostingEnvironment.WebRootPath, "PreviewDocuments");
+        
         DirectoryInfo dirInfo = new DirectoryInfo(filePath);
         if (!dirInfo.Exists)
         {
             dirInfo.Create();
         }
-        string filename = displayDocumentNumber + "_" + loggedInAlias + "_" + attachmentName;
 
-        // CodeQL [SM00395] False Positive: Path is not controlled by user inputs
-        if (!File.Exists(filePath + @"\" + filename))
+        string safeDisplayDocumentNumber = SanitizePathSegment(displayDocumentNumber, nameof(displayDocumentNumber));
+        string safeAttachmentName = SanitizePathSegment(attachmentName, nameof(attachmentName));
+        string safeLoggedInAlias = SanitizePathSegment(loggedInAlias, nameof(loggedInAlias));
+
+        string fileName = safeDisplayDocumentNumber + "_" + safeLoggedInAlias + "_" + safeAttachmentName;
+        string candidatePath = Path.Combine(filePath, fileName);
+
+        string canonicalBasePath = Path.GetFullPath(filePath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        string canonicalCandidatePath = Path.GetFullPath(candidatePath);
+
+        if (!canonicalCandidatePath.StartsWith(canonicalBasePath, StringComparison.OrdinalIgnoreCase))
         {
-            // CodeQL [SM00395] False Positive: Path is not controlled by user inputs
-            File.WriteAllBytes(filePath + @"\" + filename, officeDocumentContent);
+            throw new UnauthorizedAccessException("Invalid path: the target file path is outside the preview directory.");
         }
-        return filename;
+
+        if (!File.Exists(canonicalCandidatePath))
+        {
+            File.WriteAllBytes(canonicalCandidatePath, officeDocumentContent);
+        }
+
+        return fileName;
+    }
+
+    private static string SanitizePathSegment(string value, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Value cannot be null or empty.", parameterName);
+        }
+
+        if (value.IndexOf("..", StringComparison.Ordinal) >= 0 ||
+            value.IndexOf(Path.DirectorySeparatorChar) >= 0 ||
+            value.IndexOf(Path.AltDirectorySeparatorChar) >= 0)
+        {
+            throw new ArgumentException("Path traversal characters are not allowed.", parameterName);
+        }
+
+        string fileNameOnly = Path.GetFileName(value);
+
+        if (!string.Equals(fileNameOnly, value, StringComparison.Ordinal))
+        {
+            throw new ArgumentException("Only file name segments are allowed.", parameterName);
+        }
+
+        return fileNameOnly;
     }
 }

--- a/source/dotnet/Core/Approvals.CoreServices.BL/Helpers/OfficeDocumentCreator.cs
+++ b/source/dotnet/Core/Approvals.CoreServices.BL/Helpers/OfficeDocumentCreator.cs
@@ -39,7 +39,7 @@ public class OfficeDocumentCreator : IOfficeDocumentCreator
     public string GetDocumentURL(byte[] officeDocumentContent, string displayDocumentNumber, string attachmentName, string loggedInAlias, string sessionId)
     {
         string filePath = Path.Combine(_hostingEnvironment.WebRootPath, "PreviewDocuments");
-        
+
         DirectoryInfo dirInfo = new DirectoryInfo(filePath);
         if (!dirInfo.Exists)
         {

--- a/source/dotnet/Core/Approvals.PayloadReceiver.BL/Interface/IPayloadReceiverManager.cs
+++ b/source/dotnet/Core/Approvals.PayloadReceiver.BL/Interface/IPayloadReceiverManager.cs
@@ -13,6 +13,7 @@ public interface IPayloadReceiverManager
     /// </summary>
     /// <param name="documentTypeId">Unique TenantId (GUID) specifying a particular Tenant for which the Payload is received</param>
     /// <param name="payload">Data payload</param>
+    /// <param name="callerAppId">Caller application id from azp/appid claim.</param>
     /// <returns>Http Response Message</returns>
-    Task<JObject> ManagePost(string documentTypeId, string payload);
+    Task<JObject> ManagePost(string documentTypeId, string payload, string callerAppId = "");
 }

--- a/source/dotnet/Core/Approvals.PayloadReceiver.BL/PayloadReceiverManager.cs
+++ b/source/dotnet/Core/Approvals.PayloadReceiver.BL/PayloadReceiverManager.cs
@@ -222,11 +222,10 @@ public class PayloadReceiverManager : IPayloadReceiverManager
     private static void ValidateTenantRegisteredClient(string callerAppId, ApprovalTenantInfo tenantInfo)
     {
         bool hasRegisteredClientId = !string.IsNullOrWhiteSpace(tenantInfo?.RegisteredClientId);
-        bool hasAllowedClientList = tenantInfo?.RegisteredClientsList?.Any() == true;
 
         // Backward compatibility: do not enforce tenant-specific client checks
         // until tenant caller IDs are configured.
-        if (!hasRegisteredClientId && !hasAllowedClientList)
+        if (!hasRegisteredClientId)
         {
             return;
         }
@@ -236,13 +235,7 @@ public class PayloadReceiverManager : IPayloadReceiverManager
             throw new UnauthorizedAccessException("Caller app id (azp/appid) is missing.");
         }
 
-        bool isRegisteredClientIdMatch = hasRegisteredClientId
-            && tenantInfo.RegisteredClientId.Equals(callerAppId, StringComparison.InvariantCultureIgnoreCase);
-
-        bool isAllowedByTenantList = hasAllowedClientList
-            && tenantInfo.RegisteredClientsList.Any(id => id.Equals(callerAppId, StringComparison.InvariantCultureIgnoreCase));
-
-        if (!isRegisteredClientIdMatch && !isAllowedByTenantList)
+        if (!tenantInfo.RegisteredClientId.Equals(callerAppId, StringComparison.InvariantCultureIgnoreCase))
         {
             throw new UnauthorizedAccessException("Caller app id is not registered for the tenant.");
         }

--- a/source/dotnet/Core/Approvals.PayloadReceiver.BL/PayloadReceiverManager.cs
+++ b/source/dotnet/Core/Approvals.PayloadReceiver.BL/PayloadReceiverManager.cs
@@ -78,8 +78,9 @@ public class PayloadReceiverManager : IPayloadReceiverManager
     /// </summary>
     /// <param name="documentTypeId">Unique TenantId (GUID) specifying a particular Tenant for which the Payload is received</param>
     /// <param name="payload">Data Payload</param>
+    /// <param name="callerAppId">Caller application id from azp/appid claim.</param>
     /// <returns>Http Response Message</returns>
-    public async Task<JObject> ManagePost(string documentTypeId, string payload)
+    public async Task<JObject> ManagePost(string documentTypeId, string payload, string callerAppId = "")
     {
         JObject response = new JObject();
 
@@ -122,6 +123,8 @@ public class PayloadReceiverManager : IPayloadReceiverManager
             logData.Add(LogDataKey.TenantId, tenantInfo.TenantId);
             logData.Add(LogDataKey.TenantName, tenantInfo.AppName);
 
+            ValidateTenantRegisteredClient(callerAppId, tenantInfo);
+
             #endregion TenantId pre-condition check
 
             #region Read the payload content
@@ -152,6 +155,7 @@ public class PayloadReceiverManager : IPayloadReceiverManager
             if (!string.IsNullOrWhiteSpace(payload))
             {
                 string businessProcessName = string.Empty;
+
                 // Process payload
                 PayloadProcessingResult payloadProcessingResult = _payloadReceiver.ProcessPayload(activityId, payloadType, payload, tenantInfo, out string xcv, out string tcv, out string approvalRequestOperationType, out businessProcessName, out Dictionary<string, string> tenantTelemetry);
 
@@ -195,6 +199,11 @@ public class PayloadReceiverManager : IPayloadReceiverManager
         }
         catch (Exception ex)
         {
+            if (ex is UnauthorizedAccessException)
+            {
+                throw;
+            }
+
             logData[LogDataKey.IsCriticalEvent] = CriticalityLevel.Yes.ToString();
             _logProvider.LogError(TrackingEvent.PayloadProcessingFailure, ex, logData);
 
@@ -203,4 +212,40 @@ public class PayloadReceiverManager : IPayloadReceiverManager
 
         return response;
     }
+
+    /// <summary>
+    /// Validates that the caller application ID is registered for the specified tenant.
+    /// </summary>
+    /// <param name="callerAppId">The application ID of the calling client (from azp/appid claim).</param>
+    /// <param name="tenantInfo">The tenant information containing registered client configurations.</param>
+    /// <exception cref="UnauthorizedAccessException">Thrown when the caller app ID is missing or not registered for the tenant.</exception>
+    private static void ValidateTenantRegisteredClient(string callerAppId, ApprovalTenantInfo tenantInfo)
+    {
+        bool hasRegisteredClientId = !string.IsNullOrWhiteSpace(tenantInfo?.RegisteredClientId);
+        bool hasAllowedClientList = tenantInfo?.RegisteredClientsList?.Any() == true;
+
+        // Backward compatibility: do not enforce tenant-specific client checks
+        // until tenant caller IDs are configured.
+        if (!hasRegisteredClientId && !hasAllowedClientList)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(callerAppId))
+        {
+            throw new UnauthorizedAccessException("Caller app id (azp/appid) is missing.");
+        }
+
+        bool isRegisteredClientIdMatch = hasRegisteredClientId
+            && tenantInfo.RegisteredClientId.Equals(callerAppId, StringComparison.InvariantCultureIgnoreCase);
+
+        bool isAllowedByTenantList = hasAllowedClientList
+            && tenantInfo.RegisteredClientsList.Any(id => id.Equals(callerAppId, StringComparison.InvariantCultureIgnoreCase));
+
+        if (!isRegisteredClientIdMatch && !isAllowedByTenantList)
+        {
+            throw new UnauthorizedAccessException("Caller app id is not registered for the tenant.");
+        }
+    }
+
 }

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/CommonController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/CommonController.cs
@@ -97,6 +97,19 @@ public class CommonController : ControllerBase
     [Route("CheckUserRole/{env}")]
     public IActionResult CheckUserRole()
     {
-        return Ok(_configurationHelper.appSettings[Request.RouteValues["env"].ToString()]["AdminUserList"].Contains(Request.Headers["useralias"]));
+        var loggedInAlias = Request.Headers[Microsoft.CFS.Approvals.Contracts.Constants.LoggedInUserAlias].FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(loggedInAlias))
+            return Ok(false);
+
+        var env = Request.RouteValues["env"]?.ToString();
+        if (string.IsNullOrWhiteSpace(env) || !_configurationHelper.appSettings.ContainsKey(env))
+            return Ok(false);
+
+        var adminListValue = _configurationHelper.appSettings[env]["AdminUserList"] ?? string.Empty;
+        var adminSet = new HashSet<string>(
+            adminListValue.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+            StringComparer.OrdinalIgnoreCase);
+
+        return Ok(adminSet.Contains(loggedInAlias));
     }
 }

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/CommonController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/CommonController.cs
@@ -5,6 +5,7 @@ namespace Microsoft.CFS.Approvals.SupportService.API.Controllers.api.v1;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
@@ -17,6 +18,7 @@ using Microsoft.Extensions.Configuration;
 /// </summary>
 [Route("api/v1/Common")]
 [ApiController]
+[Authorize]
 public class CommonController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/DownTimeAlertNotificationController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/DownTimeAlertNotificationController.cs
@@ -12,7 +12,6 @@ using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
 using Microsoft.CFS.Approvals.DevTools.AppConfiguration;
 using Microsoft.CFS.Approvals.DevTools.Model.Constant;
 using Microsoft.CFS.Approvals.DevTools.Model.Models;
-using Microsoft.CFS.Approvals.SupportService.API.Filters;
 
 
 /// <summary>
@@ -20,7 +19,6 @@ using Microsoft.CFS.Approvals.SupportService.API.Filters;
 /// </summary>
 [Route("api/v1/DownTimeAlertNotification/{env}")]
 [ApiController]
-[TypeFilter(typeof(AuthorizationFilter))]
 public class DownTimeAlertNotificationController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/DownTimeAlertNotificationController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/DownTimeAlertNotificationController.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
@@ -19,6 +20,7 @@ using Microsoft.CFS.Approvals.DevTools.Model.Models;
 /// </summary>
 [Route("api/v1/DownTimeAlertNotification/{env}")]
 [ApiController]
+[Authorize]
 public class DownTimeAlertNotificationController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/MarkRequestOutOfSyncController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/MarkRequestOutOfSyncController.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.CFS.Approvals.SupportService.API.Filters;
 using Microsoft.CFS.Approvals.SupportServices.Helper.Interface;
 using Microsoft.CFS.Approvals.SupportServices.Helper.ModelBinder;
 using Newtonsoft.Json.Linq;
@@ -17,7 +16,6 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 [Route("api/v1/MarkRequestOutOfSync/{env}")]
 [ApiController]
-[TypeFilter(typeof(AuthorizationFilter))]
 public class MarkRequestOutOfSyncController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/MarkRequestOutOfSyncController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/MarkRequestOutOfSyncController.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.CFS.Approvals.SupportServices.Helper.Interface;
 using Microsoft.CFS.Approvals.SupportServices.Helper.ModelBinder;
@@ -16,6 +17,7 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 [Route("api/v1/MarkRequestOutOfSync/{env}")]
 [ApiController]
+[Authorize]
 public class MarkRequestOutOfSyncController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/PayloadReProcessingController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/PayloadReProcessingController.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.DevTools.AppConfiguration;
@@ -20,6 +21,7 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 [Route("api/v1/PayloadReProcessing/{env}")]
 [ApiController]
+[Authorize]
 public class PayloadReProcessingController : ControllerBase
 {
     private readonly ConfigurationHelper _configurationHelper;

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/RequestHistoryController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/RequestHistoryController.cs
@@ -5,6 +5,7 @@ namespace Microsoft.CFS.Approvals.SupportService.API.Controllers.api.v1;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
@@ -19,6 +20,7 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 [Route("api/v1/RequestHistory")]
 [ApiController]
+[Authorize]
 public class RequestHistoryController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/RequestStatusController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/RequestStatusController.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.CFS.Approvals.SupportService.API.Controllers.api.v1;
 using System;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
@@ -15,6 +16,7 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 [Route("api/v1/RequestStatus")]
 [ApiController]
+[Authorize]
 public class RequestStatusController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/SchemaDefinationController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/SchemaDefinationController.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.CFS.Approvals.SupportService.API.Controllers.api.v1;
 using System;
 using System.Linq;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
@@ -17,6 +18,7 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 [Route("api/v1/SchemaDefination")]
 [ApiController]
+[Authorize]
 public class SchemaDefinationController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/ServiceBusMonitoringController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/ServiceBusMonitoringController.cs
@@ -5,6 +5,7 @@ namespace Microsoft.CFS.Approvals.SupportService.API.Controllers.api.v1;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.DevTools.AppConfiguration;
@@ -15,6 +16,7 @@ using Microsoft.CFS.Approvals.SupportServices.Helper.Interface;
 /// </summary>
 [Route("api/v1/ServiceBusMonitoring")]
 [ApiController]
+[Authorize]
 public class ServiceBusMonitoringController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/SubscribeFeaturesController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/SubscribeFeaturesController.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
 using Microsoft.CFS.Approvals.DevTools.AppConfiguration;
 using Microsoft.CFS.Approvals.DevTools.Model.Models;
-using Microsoft.CFS.Approvals.SupportService.API.Filters;
 using Microsoft.CFS.Approvals.SupportServices.Helper.Interface;
 using Newtonsoft.Json.Linq;
 
@@ -19,7 +18,6 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 [Route("api/v1/SubscribeFeatures")]
 [ApiController]
-[TypeFilter(typeof(AuthorizationFilter))]
 public class SubscribeFeaturesController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/SubscribeFeaturesController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/SubscribeFeaturesController.cs
@@ -5,6 +5,7 @@ namespace Microsoft.CFS.Approvals.SupportService.API.Controllers.api.v1;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
@@ -18,6 +19,7 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 [Route("api/v1/SubscribeFeatures")]
 [ApiController]
+[Authorize]
 public class SubscribeFeaturesController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/TemplatesController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/TemplatesController.cs
@@ -5,6 +5,7 @@ namespace Microsoft.CFS.Approvals.SupportService.API.Controllers.api.v1;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
@@ -20,6 +21,7 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 [Route("api/v1/Templates")]
 [ApiController]
+[Authorize]
 public class TemplatesController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/TenantInfoController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/TenantInfoController.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
 using Microsoft.CFS.Approvals.DevTools.AppConfiguration;
 using Microsoft.CFS.Approvals.DevTools.Model.Models;
-using Microsoft.CFS.Approvals.SupportService.API.Filters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -18,7 +17,6 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 [Route("api/v1/TenantInfo")]
 [ApiController]
-[TypeFilter(typeof(AuthorizationFilter))]
 public class TenantInfoController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/TenantInfoController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/TenantInfoController.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.CFS.Approvals.SupportService.API.Controllers.api.v1;
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
@@ -17,6 +18,7 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 [Route("api/v1/TenantInfo")]
 [ApiController]
+[Authorize]
 public class TenantInfoController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/TenantOnBoardingController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/TenantOnBoardingController.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.CFS.Approvals.SupportService.API.Controllers.api.v1;
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.CFS.Approvals.SupportServices.Helper.Interface;
 using Microsoft.CFS.Approvals.SupportServices.Helper.ModelBinder;
@@ -14,6 +15,7 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 [Route("api/v1/TenantOnBoarding")]
 [ApiController]
+[Authorize]
 public class TenantOnBoardingController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/UserDelegationController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/UserDelegationController.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Model;
 using Microsoft.CFS.Approvals.SupportServices.Helper.Interface;
-using Microsoft.CFS.Approvals.SupportService.API.Filters;
 using Microsoft.CFS.Approvals.Utilities.Interface;
 using Newtonsoft.Json.Linq;
 using System.Net.Mail;
@@ -18,7 +17,6 @@ using System.Net.Mail;
 /// </summary>
 [Route("api/v1/UserDelegation")]
 [ApiController]
-[TypeFilter(typeof(AuthorizationFilter))]
 public class UserDelegationController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/UserDelegationController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Controllers/api/v1/UserDelegationController.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.CFS.Approvals.SupportService.API.Controllers;
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Model;
@@ -17,6 +18,7 @@ using System.Net.Mail;
 /// </summary>
 [Route("api/v1/UserDelegation")]
 [ApiController]
+[Authorize]
 public class UserDelegationController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Filters/AuthorizationFilter.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Filters/AuthorizationFilter.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.CFS.Approvals.Contracts;
 using Microsoft.CFS.Approvals.DevTools.AppConfiguration;
 
 namespace Microsoft.CFS.Approvals.SupportService.API.Filters
@@ -21,8 +24,42 @@ namespace Microsoft.CFS.Approvals.SupportService.API.Filters
         }
         public void OnAuthorization(AuthorizationFilterContext context)
         {
-            if (!configurationHelper.appSettings[context?.HttpContext?.Request?.RouteValues["env"]?.ToString()]["AdminUserList"].Contains(context?.HttpContext?.Request?.Headers["useralias"]))
+            ArgumentNullException.ThrowIfNull(context);
+
+            // Derive caller identity from server-set header (populated by AuthorizationMiddleware
+            // from validated X-MS-CLIENT-PRINCIPAL-NAME), never from client-controlled header
+            var loggedInAlias = context.HttpContext.Request.Headers[Constants.LoggedInUserAlias].FirstOrDefault();
+            if (string.IsNullOrWhiteSpace(loggedInAlias))
+            {
                 context.Result = new UnauthorizedResult();
+                return;
+            }
+
+            // Resolve environment from route; fall back to first configured environment
+            // (same pattern as AuthorizationMiddleware) for routes without {env}
+            var env = context.HttpContext.Request.RouteValues["env"]?.ToString();
+            if (string.IsNullOrWhiteSpace(env))
+            {
+                var environmentNames = Environment.GetEnvironmentVariable("Environmentlist");
+                env = environmentNames?.Split(',').FirstOrDefault()?.Trim();
+            }
+
+            if (string.IsNullOrWhiteSpace(env) || !configurationHelper.appSettings.ContainsKey(env))
+            {
+                context.Result = new UnauthorizedResult();
+                return;
+            }
+
+            // Parse admin list into exact-match set (semicolon-delimited) with case-insensitive comparison
+            var adminListValue = configurationHelper.appSettings[env]["AdminUserList"] ?? string.Empty;
+            var adminSet = new HashSet<string>(
+                adminListValue.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+                StringComparer.OrdinalIgnoreCase);
+
+            if (!adminSet.Contains(loggedInAlias))
+            {
+                context.Result = new UnauthorizedResult();
+            }
         }
     }
 }

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Program.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Program.cs
@@ -7,10 +7,12 @@ using Azure.Core;
 using Azure.Identity;
 using Azure.Messaging.ServiceBus.Administration;
 using Azure.Storage.Blobs;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Common.BL;
 using Microsoft.CFS.Approvals.Common.DL.Interface;
+using Microsoft.CFS.Approvals.Contracts;
 using Microsoft.CFS.Approvals.Core.BL.Factory;
 using Microsoft.CFS.Approvals.Core.BL.Interface;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Helpers;
@@ -46,6 +48,13 @@ builder.Services.AddControllers(options =>
     options.Filters.Add(new Microsoft.AspNetCore.Mvc.TypeFilterAttribute(
         typeof(Microsoft.CFS.Approvals.SupportService.API.Filters.AuthorizationFilter)));
 }).AddNewtonsoftJson();
+
+builder.Services
+    .AddAuthentication(Constants.EasyAuthScheme)
+    .AddScheme<AuthenticationSchemeOptions, EasyAuthAuthenticationHandler>(Constants.EasyAuthScheme, options =>
+    {
+    });
+
 builder.Services.AddAuthorization();
 builder.Services.AddRouting(options => options.LowercaseUrls = true);
 var appSettings = new ApplicationSettingsHelper(builder.Configuration).GetSettings();
@@ -148,6 +157,7 @@ else
 app.UseHttpsRedirection();
 app.UseRouting();
 app.UseCors(MyAllowSpecificOrigins);
+app.UseAuthentication();
 app.UseAuthorization();
 app.UseMiddleware<AuthorizationMiddleware>();
 

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Program.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Program.cs
@@ -41,7 +41,12 @@ builder.Services.AddCors(options =>
         });
 });
 
-builder.Services.AddControllers().AddNewtonsoftJson();
+builder.Services.AddControllers(options =>
+{
+    options.Filters.Add(new Microsoft.AspNetCore.Mvc.TypeFilterAttribute(
+        typeof(Microsoft.CFS.Approvals.SupportService.API.Filters.AuthorizationFilter)));
+}).AddNewtonsoftJson();
+builder.Services.AddAuthorization();
 builder.Services.AddRouting(options => options.LowercaseUrls = true);
 var appSettings = new ApplicationSettingsHelper(builder.Configuration).GetSettings();
 builder.Services.AddScoped<IServiceBusHelper, ServiceBusHelper>();

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Utils/AuthorizationMiddleware.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Utils/AuthorizationMiddleware.cs
@@ -4,27 +4,20 @@
 namespace Microsoft.CFS.Approvals.SupportService.API.Utils;
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net.Mail;
 using System.Security.Claims;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.CFS.Approvals.Contracts;
 using Microsoft.CFS.Approvals.DevTools.AppConfiguration;
 using Microsoft.CFS.Approvals.SupportServices.Helper.ServiceHelper;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 /// <summary>
 /// Custom Authorization Middleware class which takes care of additional security checks
 /// </summary>
 public class AuthorizationMiddleware : IMiddleware
 {
-    private static readonly string XMsClientPrincipalIdp = "X-MS-CLIENT-PRINCIPAL-IDP";
-    private static readonly string XMsClientPrincipal = "X-MS-CLIENT-PRINCIPAL";
-
     private readonly ConfigurationHelper _configurationHelper;
 
     /// <summary>
@@ -43,7 +36,14 @@ public class AuthorizationMiddleware : IMiddleware
     /// <returns></returns>
     public async Task InvokeAsync(HttpContext context, RequestDelegate next)
     {
-        var claims = new List<Claim>();
+        // SECURITY: Reject requests that bypass EasyAuth (App Service Authentication)
+        if (!EasyAuthPrincipalHelper.TryBuildPrincipal(context.Request.Headers, Constants.EasyAuthScheme, out var principal, out _))
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsync("Unauthorized request");
+            return;
+        }
+
         var userAlias = string.Empty;
         string environment = context?.Request?.RouteValues["env"]?.ToString();
         if (string.IsNullOrWhiteSpace(environment))
@@ -74,62 +74,73 @@ public class AuthorizationMiddleware : IMiddleware
                 }
             });
 
-            // Authorize after the user has been authenticated by App Service Authentication Service
-            if (context.Request.Headers.ContainsKey(XMsClientPrincipalIdp))
+            context.User = principal;
+
+            #region Check for Valid AppID
+
+            if (context.User != null)
             {
-                if (context.Request.Headers.ContainsKey(XMsClientPrincipal))
+                var clientAppId = GetClaimValue(context.User, "azp", "appid");
+                if (string.IsNullOrWhiteSpace(clientAppId))
                 {
-                    var clientPrincipal = JsonConvert.DeserializeObject<JObject>(
-                        Encoding.UTF8.GetString(Convert.FromBase64String(context.Request.Headers[XMsClientPrincipal].FirstOrDefault())));
-                    foreach (var claimObj in clientPrincipal["claims"]?.ToObject<JObject[]>())
-                    {
-                        claims.Add(new Claim(claimObj["typ"]?.ToString(), claimObj["val"]?.ToString()));
-                    }
-                }
-                context.User = new ClaimsPrincipal(new ClaimsIdentity(claims));
-
-                #region Check for Valid AppID
-
-                // Get list of AppIds
-                var validAppIds = Environment.GetEnvironmentVariable("ValidAppIds");
-                var listOfValidAppIds = validAppIds.Split(';');
-
-                if (context.User != null)
-                {
-                    var appid = context.User.Claims.FirstOrDefault(c => c.Type.Equals("appid")) ?? context.User.Claims.FirstOrDefault(c => c.Type.Equals("aud"));
-
-                    // if AppId is null or the AppId fetched from claims is different from the Valid AppId list value then return UnAuthorized Response
-                    if (appid == null || !listOfValidAppIds.Any(id => id.Equals(appid.Value, StringComparison.InvariantCultureIgnoreCase)))
-                    {
-                        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
-                        await context.Response.WriteAsync("Unauthorized request");
-                        return;
-                    }
-                }
-
-                #endregion Check for Valid AppID
-
-                #region Check for Reserved Headers
-
-                if (context.Request.Headers.ContainsKey(Constants.LoggedInUserAlias))
-                {
-                    // Logging the details of LoggedInUserAliasHeader header and actual logged in alias details
-                    var loggedInUserAliasHeaderValue = context.Request.Headers.FirstOrDefault(x => x.Key.ToLower().Equals(Constants.LoggedInUserAlias.ToLower())).Value.FirstOrDefault();
-
-                    // Throwing back a bad request so that this message is not processed
-                    context.Response.StatusCode = StatusCodes.Status403Forbidden;
-                    await context.Response.WriteAsync("Forbidden: You are not allowed to send a reserved httpHeader value under LoggedInUserAliasHeader. This is an invalid request and will not be processed.");
+                    context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                    await context.Response.WriteAsync("Unauthorized request");
                     return;
                 }
-                else
-                {
-                    context.Request.Headers.Add(Constants.LoggedInUserAlias, userAlias);
-                }
 
-                #endregion Check for Reserved Headers
+                var validAppIds = Environment.GetEnvironmentVariable("ValidAppIds");
+                var listOfValidAppIds = validAppIds?.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? Array.Empty<string>();
+
+                if (!listOfValidAppIds.Any(id => id.Equals(clientAppId, StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                    await context.Response.WriteAsync("Unauthorized request");
+                    return;
+                }
             }
+
+            #endregion Check for Valid AppID
+
+            #region Check for Reserved Headers
+
+            if (context.Request.Headers.ContainsKey(Constants.LoggedInUserAlias))
+            {
+                // Logging the details of LoggedInUserAliasHeader header and actual logged in alias details
+                var loggedInUserAliasHeaderValue = context.Request.Headers.FirstOrDefault(x => x.Key.ToLower().Equals(Constants.LoggedInUserAlias.ToLower())).Value.FirstOrDefault();
+
+                // Throwing back a bad request so that this message is not processed
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                await context.Response.WriteAsync("Forbidden: You are not allowed to send a reserved httpHeader value under LoggedInUserAliasHeader. This is an invalid request and will not be processed.");
+                return;
+            }
+            else
+            {
+                context.Request.Headers.Add(Constants.LoggedInUserAlias, userAlias);
+            }
+
+            #endregion Check for Reserved Headers
         }
 
         await next(context);
+    }
+
+    /// <summary>
+    /// Gets the claim value from the claims principal based on the provided claim types.
+    /// </summary>
+    /// <param name="principal">The claims principal.</param>
+    /// <param name="claimTypes">The claim types to search for.</param>
+    /// <returns>The claim value if found; otherwise, an empty string.</returns>
+    private static string GetClaimValue(ClaimsPrincipal principal, params string[] claimTypes)
+    {
+        foreach (var claimType in claimTypes)
+        {
+            var value = principal.Claims.FirstOrDefault(c => c.Type.Equals(claimType, StringComparison.InvariantCultureIgnoreCase))?.Value;
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return string.Empty;
     }
 }

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Utils/EasyAuthAuthenticationHandler.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Utils/EasyAuthAuthenticationHandler.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.CFS.Approvals.SupportService.API.Utils;
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+public class EasyAuthAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public EasyAuthAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        System.Text.Encodings.Web.UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!EasyAuthPrincipalHelper.TryBuildPrincipal(Request.Headers, Scheme.Name, out var principal, out var error))
+        {
+            return Task.FromResult(AuthenticateResult.Fail(error));
+        }
+
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Utils/EasyAuthPrincipalHelper.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SupportService.API/Utils/EasyAuthPrincipalHelper.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.CFS.Approvals.SupportService.API.Utils;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+
+internal static class EasyAuthPrincipalHelper
+{
+    internal const string XMsClientPrincipalIdp = "X-MS-CLIENT-PRINCIPAL-IDP";
+    internal const string XMsClientPrincipal = "X-MS-CLIENT-PRINCIPAL";
+
+    internal static bool TryBuildPrincipal(IHeaderDictionary headers, string authenticationType, out ClaimsPrincipal principal, out string error)
+    {
+        principal = null;
+        error = null;
+
+        if (!headers.ContainsKey(XMsClientPrincipalIdp) || !headers.ContainsKey(XMsClientPrincipal))
+        {
+            error = "EasyAuth headers are missing.";
+            return false;
+        }
+
+        var encodedPrincipal = headers[XMsClientPrincipal].FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(encodedPrincipal))
+        {
+            error = "EasyAuth principal header is empty.";
+            return false;
+        }
+
+        try
+        {
+            var claims = new List<Claim>();
+            var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(encodedPrincipal));
+
+            using var document = JsonDocument.Parse(decoded);
+            if (document.RootElement.TryGetProperty("claims", out var claimsElement) && claimsElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var claimObject in claimsElement.EnumerateArray())
+                {
+                    if (!claimObject.TryGetProperty("typ", out var typeElement) || !claimObject.TryGetProperty("val", out var valueElement))
+                    {
+                        continue;
+                    }
+
+                    var claimType = typeElement.GetString();
+                    var claimValue = valueElement.GetString();
+                    if (!string.IsNullOrWhiteSpace(claimType) && !string.IsNullOrWhiteSpace(claimValue))
+                    {
+                        claims.Add(new Claim(claimType, claimValue));
+                    }
+                }
+            }
+
+            if (!claims.Any())
+            {
+                error = "No claims found in EasyAuth principal.";
+                return false;
+            }
+
+            principal = new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType));
+            return true;
+        }
+        catch
+        {
+            error = "Invalid EasyAuth principal format.";
+            return false;
+        }
+    }
+}

--- a/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/AttachmentController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/AttachmentController.cs
@@ -6,6 +6,7 @@ namespace Microsoft.CFS.Approvals.SyntheticTransaction.API.Controllers;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
@@ -20,6 +21,7 @@ using Microsoft.CFS.Approvals.SyntheticTransaction.Helpers.Helpers;
 [Route("Attachment/{env}")]
 [ApiController]
 [Produces("text/html")]
+[Authorize]
 public class AttachmentController : ControllerBase
 {
     private readonly IBlobStorageHelper _blobStorageHelper;

--- a/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/BulkDeleteController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/BulkDeleteController.cs
@@ -6,6 +6,7 @@ namespace Microsoft.CFS.Approvals.SyntheticTransaction.API.Controllers;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.CFS.Approvals.DevTools.Model.Constant;
 using Microsoft.CFS.Approvals.LogManager.Provider.Interface;
@@ -16,6 +17,7 @@ using Microsoft.CFS.Approvals.SyntheticTransaction.Helpers.Interface;
 /// </summary>
 [Route("api/v1/BulkDelete")]
 [ApiController]
+[Authorize]
 public class BulkDeleteController : ControllerBase
 {
     private readonly IBulkDeleteHelper _bulkDeleteHelper;

--- a/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/CommonController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/CommonController.cs
@@ -6,6 +6,7 @@ namespace Microsoft.CFS.Approvals.SyntheticTransaction.API.Controllers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
@@ -23,6 +24,7 @@ using Microsoft.Extensions.Configuration;
 /// </summary>
 [Route("api/v1/Common")]
 [ApiController]
+[Authorize]
 public class CommonController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/LoadGeneratorController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/LoadGeneratorController.cs
@@ -6,6 +6,7 @@ namespace Microsoft.CFS.Approvals.SyntheticTransaction.API.Controllers;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.CFS.Approvals.DevTools.Model.Constant;
 using Microsoft.CFS.Approvals.LogManager.Provider.Interface;
@@ -18,6 +19,7 @@ using Microsoft.Extensions.Configuration;
 /// </summary>
 [Route("api/v1/LoadGenerator")]
 [ApiController]
+[Authorize]
 public class LoadGeneratorController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/SyntheticTransactionController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/SyntheticTransactionController.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
@@ -27,6 +28,7 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 [ApiController]
 [Route("api/v1/SyntheticTransaction")]
+[Authorize]
 public class SyntheticTransactionController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/TestActionsController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/TestActionsController.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
@@ -25,6 +26,7 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 [Route("api/TestActions")]
 [ApiController]
+[Authorize]
 public class TestActionsController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/TestBulkActionsController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/TestBulkActionsController.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
@@ -22,6 +23,7 @@ using Microsoft.CFS.Approvals.SyntheticTransaction.Helpers.Helpers;
 /// </summary>
 [Route("{env}/api/TestBulkActions")]
 [ApiController]
+[Authorize]
 public class TestBulkActionsController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/TestDetailsController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/TestDetailsController.cs
@@ -6,6 +6,7 @@ namespace Microsoft.CFS.Approvals.SyntheticTransaction.API.Controllers;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
@@ -22,6 +23,7 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 [Route("api/TestDetails/{env}")]
 [ApiController]
+[Authorize]
 public class TestDetailsController : ControllerBase
 {
     private readonly ITableHelper _azureStorageHelper;

--- a/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/TestDownloadDocumentController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/TestDownloadDocumentController.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
@@ -24,6 +25,7 @@ using Constants = Common.Constant.Constants;
 /// </summary>
 [Route("api/TestDownloadDocument/{env}")]
 [ApiController]
+[Authorize]
 public class TestDownloadDocumentController : ControllerBase
 {
     private readonly IBlobStorageHelper _blobStorageHelper;

--- a/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/TestHarnessEnvironment.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/TestHarnessEnvironment.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.CFS.Approvals.SyntheticTransaction.API.Controllers;
 
 using System;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 /// <summary>
@@ -11,6 +12,7 @@ using Microsoft.AspNetCore.Mvc;
 /// </summary>
 [ApiController]
 [Route("api/v1/TestHarnessEnvironment")]
+[Authorize]
 public class TestHarnessEnvironment : ControllerBase
 {
     public TestHarnessEnvironment()

--- a/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/TestPullTenantController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/TestPullTenantController.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
@@ -21,6 +22,7 @@ using Microsoft.CFS.Approvals.SyntheticTransaction.Helpers.ExtensionMethods;
 /// </summary>
 [Route("{env}/api/TestPullTenant")]
 [ApiController]
+[Authorize]
 public class TestPullTenantController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/TestPullTenantDetailsController.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Controllers/TestPullTenantDetailsController.cs
@@ -7,6 +7,7 @@ namespace Microsoft.CFS.Approvals.SyntheticTransaction.API.Controllers;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.DevTools.Model.Constant;
@@ -21,6 +22,7 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 [Route("api/TestPullTenantDetails")]
 [ApiController]
+[Authorize]
 public class TestPullTenantDetailsController : ControllerBase
 {
     /// <summary>

--- a/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Program.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Program.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net.Http;
 using AutoMapper;
 using Azure.Identity;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.CFS.Approvals.Common.BL;
@@ -16,6 +17,7 @@ using Microsoft.CFS.Approvals.DevTools.AppConfiguration;
 using Microsoft.CFS.Approvals.LogManager;
 using Microsoft.CFS.Approvals.LogManager.Provider.Interface;
 using Microsoft.CFS.Approvals.SyntheticTransaction.API.Services;
+using Microsoft.CFS.Approvals.SyntheticTransaction.API.Utils;
 using Microsoft.CFS.Approvals.SyntheticTransaction.Common.Helper;
 using Microsoft.CFS.Approvals.SyntheticTransaction.Common.Interface;
 using Microsoft.CFS.Approvals.SyntheticTransaction.Helpers.Helpers;
@@ -45,6 +47,14 @@ builder.Services.AddCors(options =>
 var appSettings = new ApplicationSettingsHelper(builder.Configuration).GetSettings();
 
 builder.Services.AddControllers().AddNewtonsoftJson();
+
+builder.Services
+    .AddAuthentication(Constants.EasyAuthScheme)
+    .AddScheme<AuthenticationSchemeOptions, EasyAuthAuthenticationHandler>(Constants.EasyAuthScheme, options =>
+    {
+    });
+
+builder.Services.AddAuthorization();
 builder.Services.AddRouting(options => options.LowercaseUrls = true);
 builder.Services.AddMemoryCache();
 builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
@@ -61,6 +71,7 @@ builder.Services.AddScoped<IAuthenticationHelper, AuthenticationHelper>();
 builder.Services.AddScoped<IPayloadReceiverHelper, PayloadReceiverHelper>();
 builder.Services.AddScoped<IBulkDeleteHelper, BulkDeleteHelper>();
 builder.Services.AddScoped<ILoadGeneratorHelper, LoadGeneratorHelper>();
+builder.Services.AddScoped<AuthorizationMiddleware>();
 // Secure credential selection for Azure resources
 #if DEBUG
     var azureCredential = new DefaultAzureCredential();  // CodeQL [SM05137] Suppress CodeQL issue since we only use DefaultAzureCredential in development environments.
@@ -106,7 +117,9 @@ else
 
 app.UseRouting();
 app.UseCors(MyAllowSpecificOrigins);
+app.UseAuthentication();
 app.UseAuthorization();
+app.UseMiddleware<AuthorizationMiddleware>();
 
 app.UseEndpoints(endpoints =>
 {

--- a/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Utils/AuthorizationMiddleware.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Utils/AuthorizationMiddleware.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.CFS.Approvals.SyntheticTransaction.API.Utils;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Mail;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.CFS.Approvals.Contracts;
+using Microsoft.CFS.Approvals.DevTools.AppConfiguration;
+
+/// <summary>
+/// Custom Authorization Middleware class which takes care of additional security checks
+/// </summary>
+public class AuthorizationMiddleware : IMiddleware
+{
+    private readonly ConfigurationHelper _configurationHelper;
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public AuthorizationMiddleware(ConfigurationHelper configurationHelper)
+    {
+        _configurationHelper = configurationHelper;
+    }
+
+    /// <summary>
+    /// Create Claims Principal from Request Headers which are added by Azure App Service Authentication (EasyAuth) and validate the required claims as applicable
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="next"></param>
+    /// <returns></returns>
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        var userAlias = string.Empty;
+        string environment = context?.Request?.RouteValues["env"]?.ToString();
+        if (string.IsNullOrWhiteSpace(environment))
+        {
+            var environmentnames = Environment.GetEnvironmentVariable("Environmentlist");
+            if (environmentnames != null)
+            {
+                environment = environmentnames.Split(',').ToList()?.FirstOrDefault()?.Trim();
+            }
+            else
+            {
+                context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+                await context.Response.WriteAsync("Configuration data is invalid");
+                return;
+            }
+        }
+
+        // Get UserPrincipalName /alias from Header
+        if (!context.Request.Headers.ContainsKey("X-MS-CLIENT-PRINCIPAL-NAME"))
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsync("Unauthorized request");
+            return;
+        }
+
+        userAlias = context.Request.Headers["X-MS-CLIENT-PRINCIPAL-NAME"].ToString();
+        var whitelistedDomains = _configurationHelper.appSettings[environment][Constants.WhitelistedDomains]?.Split(";").ToList();
+        whitelistedDomains.ForEach(domain =>
+        {
+            if (userAlias.EndsWith(domain, StringComparison.InvariantCultureIgnoreCase))
+            {
+                userAlias = new MailAddress(userAlias).User;
+            }
+        });
+
+        if (!EasyAuthPrincipalHelper.TryBuildPrincipal(context.Request.Headers, Constants.EasyAuthScheme, out var principal, out _))
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsync("Unauthorized request");
+            return;
+        }
+
+        context.User = principal;
+
+        #region Check for Valid AppID
+
+        if (context.User != null)
+        {
+            var clientAppId = GetClaimValue(context.User, "azp", "appid");
+            if (string.IsNullOrWhiteSpace(clientAppId))
+            {
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                await context.Response.WriteAsync("Unauthorized request");
+                return;
+            }
+
+            var validAppIds = Environment.GetEnvironmentVariable("ValidAppIds");
+            var listOfValidAppIds = validAppIds?.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? Array.Empty<string>();
+
+            if (!listOfValidAppIds.Any(id => id.Equals(clientAppId, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                await context.Response.WriteAsync("Unauthorized request");
+                return;
+            }
+        }
+
+        #endregion Check for Valid AppID
+
+        #region Check for Reserved Headers
+
+        if (context.Request.Headers.ContainsKey(Constants.LoggedInUserAlias))
+        {
+            // Logging the details of LoggedInUserAliasHeader header and actual logged in alias details
+            var loggedInUserAliasHeaderValue = context.Request.Headers.FirstOrDefault(x => x.Key.ToLower().Equals(Constants.LoggedInUserAlias.ToLower())).Value.FirstOrDefault();
+
+            // Throwing back a bad request so that this message is not processed
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsync("Forbidden: You are not allowed to send a reserved httpHeader value under LoggedInUserAliasHeader. This is an invalid request and will not be processed.");
+            return;
+        }
+        else
+        {
+            context.Request.Headers.Add(Constants.LoggedInUserAlias, userAlias);
+        }
+
+        #endregion Check for Reserved Headers
+
+        await next(context);
+    }
+
+    /// <summary>
+    /// Gets the claim value from the claims principal based on the provided claim types.
+    /// </summary>
+    /// <param name="principal">The claims principal.</param>
+    /// <param name="claimTypes">The claim types to search for.</param>
+    /// <returns>The claim value if found; otherwise, an empty string.</returns>
+    private static string GetClaimValue(ClaimsPrincipal principal, params string[] claimTypes)
+    {
+        foreach (var claimType in claimTypes)
+        {
+            var value = principal.Claims.FirstOrDefault(c => c.Type.Equals(claimType, StringComparison.InvariantCultureIgnoreCase))?.Value;
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return string.Empty;
+    }
+}

--- a/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Utils/EasyAuthAuthenticationHandler.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Utils/EasyAuthAuthenticationHandler.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.CFS.Approvals.SyntheticTransaction.API.Utils;
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+public class EasyAuthAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public EasyAuthAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        System.Text.Encodings.Web.UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!EasyAuthPrincipalHelper.TryBuildPrincipal(Request.Headers, Scheme.Name, out var principal, out var error))
+        {
+            return Task.FromResult(AuthenticateResult.Fail(error));
+        }
+
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Utils/EasyAuthPrincipalHelper.cs
+++ b/source/dotnet/DevTools/APIs/Approvals.SyntheticTransaction.API/Utils/EasyAuthPrincipalHelper.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.CFS.Approvals.SyntheticTransaction.API.Utils;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+
+internal static class EasyAuthPrincipalHelper
+{
+    internal const string XMsClientPrincipalIdp = "X-MS-CLIENT-PRINCIPAL-IDP";
+    internal const string XMsClientPrincipal = "X-MS-CLIENT-PRINCIPAL";
+
+    internal static bool TryBuildPrincipal(IHeaderDictionary headers, string authenticationType, out ClaimsPrincipal principal, out string error)
+    {
+        principal = null;
+        error = null;
+
+        if (!headers.ContainsKey(XMsClientPrincipalIdp) || !headers.ContainsKey(XMsClientPrincipal))
+        {
+            error = "EasyAuth headers are missing.";
+            return false;
+        }
+
+        var encodedPrincipal = headers[XMsClientPrincipal].FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(encodedPrincipal))
+        {
+            error = "EasyAuth principal header is empty.";
+            return false;
+        }
+
+        try
+        {
+            var claims = new List<Claim>();
+            var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(encodedPrincipal));
+
+            using var document = JsonDocument.Parse(decoded);
+            if (document.RootElement.TryGetProperty("claims", out var claimsElement) && claimsElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var claimObject in claimsElement.EnumerateArray())
+                {
+                    if (!claimObject.TryGetProperty("typ", out var typeElement) || !claimObject.TryGetProperty("val", out var valueElement))
+                    {
+                        continue;
+                    }
+
+                    var claimType = typeElement.GetString();
+                    var claimValue = valueElement.GetString();
+                    if (!string.IsNullOrWhiteSpace(claimType) && !string.IsNullOrWhiteSpace(claimValue))
+                    {
+                        claims.Add(new Claim(claimType, claimValue));
+                    }
+                }
+            }
+
+            if (!claims.Any())
+            {
+                error = "No claims found in EasyAuth principal.";
+                return false;
+            }
+
+            principal = new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType));
+            return true;
+        }
+        catch
+        {
+            error = "Invalid EasyAuth principal format.";
+            return false;
+        }
+    }
+}

--- a/source/dotnet/UnitTests/Approvals.Core.BL.UnitTests/Approvals.Core.BL.UnitTests.csproj
+++ b/source/dotnet/UnitTests/Approvals.Core.BL.UnitTests/Approvals.Core.BL.UnitTests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>Microsoft.CFS.Approvals.Core.BL.UnitTests</AssemblyName>
+    <RootNamespace>Microsoft.CFS.Approvals.Core.BL.UnitTests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Approvals.Core.BL\Approvals.Core.BL.csproj" />
+    <ProjectReference Include="..\..\Core\Approvals.Common.BL\Approvals.Common.BL.csproj" />
+    <ProjectReference Include="..\..\Common\Approvals.Utilities\Approvals.Utilities.csproj" />
+    <ProjectReference Include="..\..\Common\Approvals.Data.Azure.Storage\Approvals.Data.Azure.Storage.csproj" />
+    <ProjectReference Include="..\..\Common\Approvals.LogManager\Approvals.LogManager.csproj" />
+    <ProjectReference Include="..\..\Contract\Approvals.Model\Approvals.Model.csproj" />
+    <ProjectReference Include="..\..\Contract\Approvals.Contracts\Approvals.Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/source/dotnet/UnitTests/Approvals.Core.BL.UnitTests/DetailsHelperGetAllAttachmentsInBulkTests.cs
+++ b/source/dotnet/UnitTests/Approvals.Core.BL.UnitTests/DetailsHelperGetAllAttachmentsInBulkTests.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.CFS.Approvals.Core.BL.UnitTests;
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.CFS.Approvals.Common.BL.Interface;
+using Microsoft.CFS.Approvals.Common.DL.Interface;
+using Microsoft.CFS.Approvals.Contracts.DataContracts;
+using Microsoft.CFS.Approvals.Core.BL.Helpers;
+using Microsoft.CFS.Approvals.Core.BL.Interface;
+using Microsoft.CFS.Approvals.Data.Azure.Storage.Interface;
+using Microsoft.CFS.Approvals.LogManager.Provider.Interface;
+using Microsoft.CFS.Approvals.Model;
+using Microsoft.CFS.Approvals.Utilities.Interface;
+using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Newtonsoft.Json;
+
+/// <summary>
+/// Security regression test for the V11 bulk-attachment-download IDOR fix: a caller must not be able
+/// to retrieve another user's attachments by supplying an arbitrary UserAlias unless server-side
+/// delegation validation (IDelegationHelper.CheckUserAuthorization) actually grants access.
+/// </summary>
+[TestClass]
+public class DetailsHelperGetAllAttachmentsInBulkTests
+{
+    private Mock<IDelegationHelper> mockDelegationHelper = null!;
+    private Mock<IActionAuditLogHelper> mockActionAuditLogHelper = null!;
+    private Mock<ILogProvider> mockLogProvider = null!;
+    private Mock<IPerformanceLogger> mockPerformanceLogger = null!;
+    private Mock<IApprovalTenantInfoHelper> mockApprovalTenantInfoHelper = null!;
+    private Mock<IConfiguration> mockConfiguration = null!;
+    private Mock<INameResolutionHelper> mockNameResolutionHelper = null!;
+    private Mock<IApprovalDetailProvider> mockApprovalDetailProvider = null!;
+    private Mock<IFlightingDataProvider> mockFlightingDataProvider = null!;
+    private Mock<IEditableConfigurationHelper> mockEditableConfigurationHelper = null!;
+    private Mock<ISummaryHelper> mockSummaryHelper = null!;
+    private Mock<IApprovalHistoryProvider> mockApprovalHistoryProvider = null!;
+    private Mock<ITenantFactory> mockTenantFactory = null!;
+    private Mock<IImageRetriever> mockImageRetriever = null!;
+    private Mock<IBlobStorageHelper> mockBlobStorageHelper = null!;
+    private Mock<IHttpHelper> mockHttpHelper = null!;
+    private Mock<IReadDetailsHelper> mockReadDetailsHelper = null!;
+    private DetailsHelper detailsHelper = null!;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        mockDelegationHelper = new Mock<IDelegationHelper>();
+        mockActionAuditLogHelper = new Mock<IActionAuditLogHelper>();
+        mockLogProvider = new Mock<ILogProvider>();
+        mockPerformanceLogger = new Mock<IPerformanceLogger>();
+        mockApprovalTenantInfoHelper = new Mock<IApprovalTenantInfoHelper>();
+        mockConfiguration = new Mock<IConfiguration>();
+        mockNameResolutionHelper = new Mock<INameResolutionHelper>();
+        mockApprovalDetailProvider = new Mock<IApprovalDetailProvider>();
+        mockFlightingDataProvider = new Mock<IFlightingDataProvider>();
+        mockEditableConfigurationHelper = new Mock<IEditableConfigurationHelper>();
+        mockSummaryHelper = new Mock<ISummaryHelper>();
+        mockApprovalHistoryProvider = new Mock<IApprovalHistoryProvider>();
+        mockTenantFactory = new Mock<ITenantFactory>();
+        mockImageRetriever = new Mock<IImageRetriever>();
+        mockBlobStorageHelper = new Mock<IBlobStorageHelper>();
+        mockHttpHelper = new Mock<IHttpHelper>();
+        mockReadDetailsHelper = new Mock<IReadDetailsHelper>();
+
+        mockApprovalTenantInfoHelper
+            .Setup(x => x.GetTenantInfo(It.IsAny<int>()))
+            .Returns(new ApprovalTenantInfo { AppName = "TestApp", BusinessProcessName = "{0}.{1}" });
+
+        detailsHelper = new DetailsHelper(
+            mockDelegationHelper.Object,
+            mockActionAuditLogHelper.Object,
+            mockLogProvider.Object,
+            mockPerformanceLogger.Object,
+            mockApprovalTenantInfoHelper.Object,
+            mockConfiguration.Object,
+            mockNameResolutionHelper.Object,
+            mockApprovalDetailProvider.Object,
+            mockFlightingDataProvider.Object,
+            mockEditableConfigurationHelper.Object,
+            mockSummaryHelper.Object,
+            mockApprovalHistoryProvider.Object,
+            mockTenantFactory.Object,
+            mockImageRetriever.Object,
+            mockBlobStorageHelper.Object,
+            mockHttpHelper.Object,
+            mockReadDetailsHelper.Object);
+    }
+
+    /// <summary>
+    /// A caller (attacker) requesting another user's (victim) attachments must be rejected with
+    /// UnauthorizedAccessException when server-side delegation validation denies the grant, and the
+    /// request must never reach the tenant adapter.
+    /// </summary>
+    [TestMethod]
+    public async Task GetAllAttachmentsInBulk_UnauthorizedDelegate_ThrowsAndNeverCallsTenant()
+    {
+        mockDelegationHelper
+            .Setup(x => x.CheckUserAuthorization(It.IsAny<User>(), It.IsAny<User>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ThrowsAsync(new UnauthorizedAccessException("User doesn't have permission to see the report."));
+
+        var attackerUser = new User { MailNickname = "attacker", UserPrincipalName = "attacker@microsoft.com", Id = Guid.NewGuid().ToString() };
+        var approvalRequests = new List<ApprovalRequest>
+        {
+            new ApprovalRequest { ApprovalIdentifier = new ApprovalIdentifier { DisplayDocumentNumber = "DOC1" } }
+        };
+
+        await Assert.ThrowsExceptionAsync<UnauthorizedAccessException>(() =>
+            detailsHelper.GetAllAttachmentsInBulk(
+                1, string.Empty, string.Empty, JsonConvert.SerializeObject(approvalRequests),
+                "victimAlias", attackerUser, "Web", string.Empty, Guid.NewGuid().ToString(), "@microsoft.com"));
+
+        mockTenantFactory.Verify(
+            x => x.GetTenant(It.IsAny<ApprovalTenantInfo>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never);
+    }
+}

--- a/source/dotnet/UnitTests/Approvals.CoreServices.BL.UnitTests/Approvals.CoreServices.BL.UnitTests.csproj
+++ b/source/dotnet/UnitTests/Approvals.CoreServices.BL.UnitTests/Approvals.CoreServices.BL.UnitTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>Microsoft.CFS.Approvals.CoreServices.BL.UnitTests</AssemblyName>
+    <RootNamespace>Microsoft.CFS.Approvals.CoreServices.BL.UnitTests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Approvals.CoreServices.BL\Approvals.CoreServices.BL.csproj" />
+  </ItemGroup>
+</Project>

--- a/source/dotnet/UnitTests/Approvals.CoreServices.BL.UnitTests/OfficeDocumentCreatorTests.cs
+++ b/source/dotnet/UnitTests/Approvals.CoreServices.BL.UnitTests/OfficeDocumentCreatorTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.CFS.Approvals.CoreServices.BL.UnitTests;
+
+using System;
+using System.IO;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.CFS.Approvals.CoreServices.BL.Helpers;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+[TestClass]
+public class OfficeDocumentCreatorTests
+{
+    private string tempRootPath = string.Empty;
+    private OfficeDocumentCreator officeDocumentCreator = null!;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        tempRootPath = Path.Combine(Path.GetTempPath(), "OfficeDocumentCreatorTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRootPath);
+
+        Mock<IHostingEnvironment> hostingEnvironmentMock = new();
+        hostingEnvironmentMock.SetupGet(env => env.ApplicationName).Returns("Approvals.CoreServices.BL.UnitTests");
+        hostingEnvironmentMock.SetupGet(env => env.EnvironmentName).Returns("UnitTest");
+        hostingEnvironmentMock.SetupGet(env => env.ContentRootPath).Returns(tempRootPath);
+        hostingEnvironmentMock.SetupGet(env => env.WebRootPath).Returns(tempRootPath);
+        hostingEnvironmentMock.SetupGet(env => env.ContentRootFileProvider).Returns(new NullFileProvider());
+        hostingEnvironmentMock.SetupGet(env => env.WebRootFileProvider).Returns(new NullFileProvider());
+
+        officeDocumentCreator = new OfficeDocumentCreator(hostingEnvironmentMock.Object);
+    }
+
+    [TestMethod]
+    public void GetDocumentURL_ShouldCreateFileInPreviewDocumentsAndReturnExpectedFileName()
+    {
+        byte[] officeDocumentContent = [1, 2, 3, 4, 5];
+        string displayDocumentNumber = "DOC123";
+        string attachmentName = "invoice.docx";
+        string loggedInAlias = "jdoe";
+        string sessionId = "session-1";
+
+        string result = officeDocumentCreator.GetDocumentURL(
+            officeDocumentContent,
+            displayDocumentNumber,
+            attachmentName,
+            loggedInAlias,
+            sessionId);
+
+        string expectedFileName = "DOC123_jdoe_invoice.docx";
+        string expectedPath = Path.Combine(tempRootPath, "PreviewDocuments", expectedFileName);
+
+        Assert.AreEqual(expectedFileName, result);
+        Assert.IsTrue(File.Exists(expectedPath));
+        CollectionAssert.AreEqual(officeDocumentContent, File.ReadAllBytes(expectedPath));
+    }
+
+    [TestMethod]
+    public void GetDocumentURL_ShouldThrowArgumentException_WhenAttachmentNameContainsPathTraversal()
+    {
+        byte[] officeDocumentContent = [1, 2, 3];
+        string displayDocumentNumber = "DOC123";
+        string attachmentName = "../invoice.docx";
+        string loggedInAlias = "jdoe";
+        string sessionId = "session-1";
+
+        ArgumentException exception = Assert.ThrowsException<ArgumentException>(() =>
+            officeDocumentCreator.GetDocumentURL(
+                officeDocumentContent,
+                displayDocumentNumber,
+                attachmentName,
+                loggedInAlias,
+                sessionId));
+
+        Assert.AreEqual("attachmentName", exception.ParamName);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(tempRootPath))
+        {
+            Directory.Delete(tempRootPath, true);
+        }
+    }
+}

--- a/source/reactjs/src/Helpers/sharedHelpers.tsx
+++ b/source/reactjs/src/Helpers/sharedHelpers.tsx
@@ -73,6 +73,120 @@ export const flattenObject = (ob: any): any => {
     return toReturn;
 };
 
+const formatConditionValue = (value: any): string => {
+    if (value !== null && value !== undefined && value !== '' && !isNaN(Number(value))) {
+        return String(Number(value));
+    }
+    return JSON.stringify(value) ?? 'null';
+};
+
+// Binary operators supported by the tenant condition DSL (precedence, evaluator).
+const CONDITION_OPS: { [op: string]: [number, (l: any, r: any) => any] } = {
+    '||': [1, (l, r) => l || r],
+    '&&': [2, (l, r) => l && r],
+    '==': [3, (l, r) => l == r], // eslint-disable-line eqeqeq
+    '===': [3, (l, r) => l === r],
+    '!=': [3, (l, r) => l != r], // eslint-disable-line eqeqeq
+    '!==': [3, (l, r) => l !== r],
+    '<': [4, (l, r) => l < r],
+    '<=': [4, (l, r) => l <= r],
+    '>': [4, (l, r) => l > r],
+    '>=': [4, (l, r) => l >= r],
+};
+
+// Eval-free replacement for `new Function('return ' + condition)()`: evaluates only literals + allowed operators, else throws.
+const evaluateConditionExpression = (condition: string): boolean => {
+    const tokens =
+        condition.match(
+            /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|-?\d+\.?\d*|===|!==|[=!<>]=|&&|\|\||[<>!().,]|[A-Za-z_$][\w$]*/g
+        ) || [];
+    let pos = 0;
+
+    const primary = (): any => {
+        const t = tokens[pos++];
+        if (t === '(') {
+            const v = binary(0);
+            if (tokens[pos++] !== ')') throw new Error('Invalid condition');
+            return v;
+        }
+        if (t === 'true') return true;
+        if (t === 'false') return false;
+        if (t === 'null') return null;
+        if (t === 'undefined') return undefined;
+        if (t && t[0] === '"') return JSON.parse(t);
+        if (t && t[0] === "'") return t.slice(1, -1).replace(/\\(.)/g, '$1');
+        if (t && /^-?\d/.test(t)) return Number(t);
+        throw new Error('Invalid condition token: ' + t);
+    };
+
+    const postfix = (): any => {
+        let value = primary();
+        while (tokens[pos] === '.') {
+            pos++;
+            const name = tokens[pos++];
+            if (!name || !/^[A-Za-z_$][\w$]*$/.test(name)) throw new Error('Invalid condition');
+            if (tokens[pos] === '(') {
+                pos++;
+                const args: any[] = [];
+                if (tokens[pos] !== ')') {
+                    args.push(binary(0));
+                    while (tokens[pos] === ',') {
+                        pos++;
+                        args.push(binary(0));
+                    }
+                }
+                if (tokens[pos++] !== ')') throw new Error('Invalid condition');
+                if (!CONDITION_SAFE_METHODS.has(name) || value == null || typeof value[name] !== 'function') {
+                    throw new Error('Unsupported condition method: ' + name);
+                }
+                value = value[name](...args);
+            } else {
+                if (!CONDITION_SAFE_PROPS.has(name) || value == null) {
+                    throw new Error('Unsupported condition property: ' + name);
+                }
+                value = value[name];
+            }
+        }
+        return value;
+    };
+
+    const unary = (): any => {
+        if (tokens[pos] === '!') {
+            pos++;
+            return !unary();
+        }
+        return postfix();
+    };
+
+    function binary(min: number): any {
+        let left = unary();
+        for (let op = CONDITION_OPS[tokens[pos]]; op && op[0] >= min; op = CONDITION_OPS[tokens[pos]]) {
+            pos++;
+            left = op[1](left, binary(op[0] + 1));
+        }
+        return left;
+    }
+
+    const result = binary(0);
+    if (pos !== tokens.length) throw new Error('Invalid condition');
+    return Boolean(result);
+};
+
+// An unparseable tenant condition must never crash an approval action: log it and fall back.
+const safeEvaluateCondition = (condition: string, fallback: boolean): boolean => {
+    try {
+        return evaluateConditionExpression(condition);
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('MSApprovals: unable to evaluate tenant condition; using fallback', {
+            condition,
+            fallback,
+            error,
+        });
+        return fallback;
+    }
+};
+
 export const validateConditionClient = (propertyObject: any, condition: string): boolean => {
     const conditionPhrases = condition.match(/(\w+[^\w\s]\w+)|(\w+\s)/g);
     if (conditionPhrases) {
@@ -88,11 +202,10 @@ export const validateConditionClient = (propertyObject: any, condition: string):
                 propertyName = toCamelCase(propertyName);
             }
             propertyName = propertyName.trim();
-            condition = condition.replace(conditionPhrase.trim(), '"' + propertyObject[propertyName] + '"');
+            condition = condition.replace(conditionPhrase.trim(), formatConditionValue(propertyObject[propertyName]));
         });
     }
-    const result = new Function('return ' + condition)();
-    return result;
+    return safeEvaluateCondition(condition, true);
 };
 
 export const validateCondition = (propertyObject: any, condition: string): boolean => {
@@ -110,11 +223,10 @@ export const validateCondition = (propertyObject: any, condition: string): boole
                         propertyName = toCamelCase(propertyName);
                     }
                     propertyName = propertyName.trim();
-                    condition = condition.replace(conditionPhrase.trim(), '"' + propertyObject[propertyName] + '"');
+                    condition = condition.replace(conditionPhrase.trim(), formatConditionValue(propertyObject[propertyName]));
                 });
             }
-            const result = new Function('return ' + condition)();
-            return result;
+            return safeEvaluateCondition(condition, true);
         }
     }
     return true;

--- a/source/reactjs/src/tests/Helpers/sharedHelpers.condition.test.ts
+++ b/source/reactjs/src/tests/Helpers/sharedHelpers.condition.test.ts
@@ -1,0 +1,71 @@
+import { validateConditionClient, validateCondition } from '../../Helpers/sharedHelpers';
+
+// Security regression tests: injected values (e.g. `a"-attackMarker()-"a`) must stay inert literals, never execute.
+describe('sharedHelpers condition DSL security', () => {
+    // Marker that only a code break-out would call; must never be invoked.
+    const attackMarker = jest.fn();
+
+    beforeEach(() => {
+        attackMarker.mockClear();
+        (globalThis as any).attackMarker = attackMarker;
+    });
+
+    afterAll(() => {
+        delete (globalThis as any).attackMarker;
+    });
+
+    // A payload that closes the string literal, injects a call, and reopens it.
+    const INJECTION = 'a"-attackMarker()-"a';
+
+    describe('validateConditionClient', () => {
+        it('evaluates a matching condition to true', () => {
+            expect(validateConditionClient({ status: 'Approved' }, 'Status == "Approved"')).toBe(true);
+        });
+
+        it('evaluates a non-matching condition to false', () => {
+            expect(validateConditionClient({ status: 'Rejected' }, 'Status == "Approved"')).toBe(false);
+        });
+
+        it('treats an injected value as a literal string and never executes it', () => {
+            let result: boolean | undefined;
+            expect(() => {
+                result = validateConditionClient({ status: INJECTION }, 'Status == "Approved"');
+            }).not.toThrow();
+            expect(result).toBe(false);
+            expect(attackMarker).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('validateCondition', () => {
+        it('returns true when there is no condition', () => {
+            expect(validateCondition({}, '')).toBe(true);
+        });
+
+        it('evaluates a _client condition to true when matching', () => {
+            expect(validateCondition({ status: 'Approved' }, '_client^Status == "Approved"')).toBe(true);
+        });
+
+        it('evaluates a _client condition to false when not matching', () => {
+            expect(validateCondition({ status: 'Rejected' }, '_client^Status == "Approved"')).toBe(false);
+        });
+
+        it('treats an injected value as a literal string and never executes it', () => {
+            let result: boolean | undefined;
+            expect(() => {
+                result = validateCondition({ status: INJECTION }, '_client^Status == "Approved"');
+            }).not.toThrow();
+            expect(result).toBe(false);
+            expect(attackMarker).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('evaluator security hardening', () => {
+        // Member access is limited to a read-only allowlist; constructor/prototype breakouts must throw, never execute.
+        it('blocks constructor breakout attempts without executing them', () => {
+            expect(() =>
+                validateConditionClient({ status: '"".constructor("attackMarker()")()' }, 'Status == "x"')
+            ).not.toThrow();
+            expect(attackMarker).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Mechanical, source-first port of the AP Platform and MSAM Web changes associated with V8, V25, V22, V11, and V18. The branch was rebuilt from public `main`; only source-backed hunks and minimal public test/layout adaptations are included.

## Source baselines

- Public assent-app base: `5263574c78fa6239ba25a30a427771b447861f7b`
- AP Platform source: refreshed `main`/`develop` and cited PR commits below
- MSAM Web source: `main` `38ba25eef2dd02906388c7c0c66b8ff718641d70`; V18 source on `develop` `9b7f758859acfd75a53e3e379954601025db0220`

## Migration method

- Applied path-filtered source commit diffs and reconciled only older-public-snapshot context conflicts.
- Excluded unrelated paths from bundled Hercules PRs.
- Added only focused test-project scaffolding where the public snapshot lacked the source test projects.
- Removed all public-only remediation/hardening that did not exist in AP Platform or MSAM Web.

## Ordered source ledger

| Public commit | Finding | Source PRs / commits | Ported scope | Adaptations / exclusions |
|---|---|---|---|---|
| `c4d3e09f` | V18 condition code injection | MSAM PR 2068499 / nested PR 2068970; squash `9b7f7588`; relevant `d2760ebe`, `293c5c39` | Exact condition evaluator hunks in `sharedHelpers.tsx`; focused condition test | Excluded pipeline, banner XSS, saga, delegation, role, `encodeHTML`, and later unmerged PR 2075472 changes. Preserved source's undefined allowlist identifiers exactly. |
| `992615af` | V22 document-preview path traversal | AP PR 2063303; merge `6ceb1ead`; `a8e3a836`, revised by `691f9d43` | `OfficeDocumentCreator` canonical containment and segment validation; generic preview error contract; focused tests | Excluded bundled SSRF, AuthenticationHelper, DeepSearch, PayloadReprocessing, and HTTP-client changes. Added minimal public test-project scaffolding. |
| `45b251d0` | V25 SupportService admin authorization | AP PR 1970232; merge `3490ff1c`; `81039ad4`, `d531bb2e` | Global authorization filter, server-derived `LoggedInUserAlias`, exact case-insensitive admin matching, CommonController role check, redundant filter removal | Global filter covers RequestHistoryController. No AP source commit fixes its raw KQL/OData substitution, so no invented query fix is included. |
| `fd95d01d` | V8 application authentication | AP PR 1970197 (`cf580bda`), PR 1979371 (`39e03df4`), PR 1985757 (`850eb9da`), PR 2050549 (`0efac209`) | Fail-closed EasyAuth principal handling; `azp` then `appid`, never `aud`; controller `[Authorize]`; Core/Support/Synthetic handlers, middleware, and registration; PayloadReceiver tenant caller propagation | Excluded unrelated PoP, SSRF, telemetry, RBAC, DeepSearch, and Synthetic admin-filter paths. |
| `61061abd` | V11 UserAlias IDOR / delegation | AP PR 2033777 (`4d79c83f`), PR 2054149 (`c6e6c3dc`), PR 2069064 (`82b3b90a`) | PullTenant server alias overwrite; signed-in-user delegation lookup; bulk attachment/action authorization; controller/interface updates; focused unauthorized-delegate test | Excluded reverted, unmerged, and public-only middleware/GetDetails/PullTenant/Insights/default-enum completion paths. |
| `7d595d1a` | Cleanup | Source-patch cleanup | Removed the single trailing-whitespace line introduced by the V22 patch | No behavior change. |
| `b176c0ee` | V8 source completeness | AP PR 1979371 commits `c624c694`, `18f7f2c1` | Final `RegisteredClientId`-only validation and PayloadReceiver `UseAuthorization()` | Exact missing AP hunks identified by final source-fidelity review. |

## Validation

- Seven affected backend projects built successfully with 0 errors.
- Focused retained tests passed: **3/3**.
  - OfficeDocumentCreator path traversal: 2/2.
  - Bulk attachment delegation authorization: 1/1.
- `git diff --check origin/main...HEAD`: clean.
- Internal URL/feed/credential scan: zero matches.
- Working tree and pushed branch are synchronized.
- Independent final review was restricted to source fidelity and found no remaining missing/mismatched source hunks after `b176c0ee`.

## Inherited source gaps

These are deliberately not repaired because this PR is a port, not a redesign:

- **V25:** AP Platform still contains raw RequestHistory KQL placeholder substitution and raw `requestType` table filtering; no AP source fix was found.
- **V8:** AP Platform still lacks token `tid` validation and complete PayloadReceiver framework authentication registration; this port includes only source `UseAuthorization()`.
- **V11:** AP Platform still lacks parts of the pasted middleware/GetDetails/PullTenant/Insights/fail-closed-default remediation; reverted or unmerged attempts were not treated as shipped source.
- **V18:** the merged MSAM source references undefined `CONDITION_SAFE_METHODS` and `CONDITION_SAFE_PROPS`. TypeScript 4.5.5 reproduces `TS2304` at `sharedHelpers.tsx:139` and `:144`; this was preserved exactly per source-port requirements.

## Explicit exclusions

V19 Key Vault/template work, dependency upgrades, MSAL/toolchain changes, SSRF, banner XSS, Adobe, editable-details, AutoMapper, xlsx, internal pipeline/configuration, telemetry/ICM, private packages, feeds, credentials, and all unrelated bundled Hercules paths.